### PR TITLE
Replaced spa with hua

### DIFF
--- a/pyincore/analyses/housingunitallocation/housingunitallocation.ipynb
+++ b/pyincore/analyses/housingunitallocation/housingunitallocation.ipynb
@@ -74,15 +74,15 @@
     }
    ],
    "source": [
-    "spa = HousingUnitAllocation(client)\n",
+    "hua = HousingUnitAllocation(client)\n",
     "\n",
-    "spa.load_remote_input_dataset(\"housing_unit_inventory\", housing_unit_inv)\n",
-    "spa.load_remote_input_dataset(\"address_point_inventory\", address_point_inv)\n",
-    "spa.load_remote_input_dataset(\"building_inventory\", building_inv)\n",
+    "hua.load_remote_input_dataset(\"housing_unit_inventory\", housing_unit_inv)\n",
+    "hua.load_remote_input_dataset(\"address_point_inventory\", address_point_inv)\n",
+    "hua.load_remote_input_dataset(\"building_inventory\", building_inv)\n",
     "\n",
-    "spa.set_parameter(\"result_name\", result_name)\n",
-    "spa.set_parameter(\"seed\", seed)\n",
-    "spa.set_parameter(\"iterations\", iterations)"
+    "hua.set_parameter(\"result_name\", result_name)\n",
+    "hua.set_parameter(\"seed\", seed)\n",
+    "hua.set_parameter(\"iterations\", iterations)"
    ]
   },
   {
@@ -106,7 +106,7 @@
     }
    ],
    "source": [
-    "spa.run_analysis()"
+    "hua.run_analysis()"
    ]
   },
   {


### PR DESCRIPTION
The acronym spa was a hold over from an earlier version when the Housing Unit Allocation was called Stochastic Population Allocation.
spa needs to be replaced with hua, for consistency with the algorithm's name