### PR TITLE
Replace SPA acronym with HUA

### DIFF
--- a/pyincore/analyses/housingunitallocation/housingunitallocation.ipynb
+++ b/pyincore/analyses/housingunitallocation/housingunitallocation.ipynb
@@ -56,15 +56,15 @@
    },
    "outputs": [],
    "source": [
-    "spa = HousingUnitAllocation(client)\n",
+    "hua = HousingUnitAllocation(client)\n",
     "\n",
-    "spa.load_remote_input_dataset(\"housing_unit_inventory\", housing_unit_inv)\n",
-    "spa.load_remote_input_dataset(\"address_point_inventory\", address_point_inv)\n",
-    "spa.load_remote_input_dataset(\"building_inventory\", building_inv)\n",
+    "hua.load_remote_input_dataset(\"housing_unit_inventory\", housing_unit_inv)\n",
+    "hua.load_remote_input_dataset(\"address_point_inventory\", address_point_inv)\n",
+    "hua.load_remote_input_dataset(\"building_inventory\", building_inv)\n",
     "\n",
-    "spa.set_parameter(\"result_name\", result_name)\n",
-    "spa.set_parameter(\"seed\", seed)\n",
-    "spa.set_parameter(\"iterations\", iterations)"
+    "hua.set_parameter(\"result_name\", result_name)\n",
+    "hua.set_parameter(\"seed\", seed)\n",
+    "hua.set_parameter(\"iterations\", iterations)"
    ]
   },
   {
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "spa.run_analysis()"
+    "hua.run_analysis()"
    ]
   },
   {


### PR DESCRIPTION
The SPA acronym was for Stochastic Population Allocation. The term was changed to Housing Unit Allocation. 
The correct acronym should be HUA