### PR TITLE
32 epfdamage liquefaction and LS name fixes. 

### DIFF
--- a/pyincore/analyses/epfdamage/epfdamage.py
+++ b/pyincore/analyses/epfdamage/epfdamage.py
@@ -4,7 +4,6 @@
 # terms of the Mozilla Public License v2.0 which accompanies this distribution,
 # and is available at https://www.mozilla.org/en-US/MPL/2.0/
 
-import collections
 import concurrent.futures
 from itertools import repeat
 
@@ -51,11 +50,8 @@ class EpfDamage(BaseAnalysis):
         if self.get_parameter("use_hazard_uncertainty") is not None:
             use_hazard_uncertainty = self.get_parameter("use_hazard_uncertainty")
 
-        # Liquefaction
-        use_liquefaction = False
-        if self.get_parameter("use_liquefaction") is not None:
-            use_liquefaction = self.get_parameter("use_liquefaction")
-        liq_geology_dataset_id = self.get_parameter("liquefaction_geology_dataset_id")
+        if use_hazard_uncertainty:
+            raise ValueError("Uncertainty is not implemented yet.")
 
         user_defined_cpu = 1
 
@@ -75,10 +71,7 @@ class EpfDamage(BaseAnalysis):
         (ds_results, damage_results) = self.epf_damage_concurrent_future(self.epf_damage_analysis_bulk_input,
                                                                          num_workers,
                                                                          inventory_args, repeat(hazard_type),
-                                                                         repeat(hazard_dataset_id),
-                                                                         repeat(use_hazard_uncertainty),
-                                                                         repeat(use_liquefaction),
-                                                                         repeat(liq_geology_dataset_id))
+                                                                         repeat(hazard_dataset_id))
 
         self.set_result_csv_data("result", ds_results, name=self.get_parameter("result_name"))
         self.set_result_json_data("metadata", damage_results,
@@ -108,30 +101,47 @@ class EpfDamage(BaseAnalysis):
 
         return output_ds, output_dmg
 
-    def epf_damage_analysis_bulk_input(self, epfs, hazard_type, hazard_dataset_id,
-                                       use_hazard_uncertainty, use_liquefaction, liq_geology_dataset_id):
+    def epf_damage_analysis_bulk_input(self, epfs, hazard_type, hazard_dataset_id):
         """Run analysis for multiple epfs.
 
         Args:
             epfs (list): Multiple epfs from input inventory set.
             hazard_type (str): A type of hazard exposure (earthquake, tsunami, tornado, or hurricane).
             hazard_dataset_id (str): An id of the hazard exposure.
-            use_hazard_uncertainty (bool):  Hazard uncertainty. True for using uncertainty when computing damage,
-                False otherwise.
-            use_liquefaction (bool): Liquefaction. True for using liquefaction information to modify the damage,
-                False otherwise.
-            liq_geology_dataset_id (str): geology_dataset_id (str): A dataset id for geology dataset for liquefaction.
 
         Returns:
             list: A list of ordered dictionaries with epf damage values and other data/metadata.
 
         """
+
+        use_liquefaction = False
+        liquefaction_available = False
+
         fragility_key = self.get_parameter("fragility_key")
 
         fragility_set = self.fragilitysvc.match_inventory(self.get_input_dataset("dfr3_mapping_set"), epfs,
                                                           fragility_key)
 
+        if hazard_type == "earthquake":
+            liquefaction_fragility_key = self.get_parameter("liquefaction_fragility_key")
+            if self.get_parameter("use_liquefaction") is True:
+                if liquefaction_fragility_key is None:
+                    liquefaction_fragility_key = self.DEFAULT_LIQ_FRAGILITY_KEY
+
+                use_liquefaction = self.get_parameter("use_liquefaction")
+
+                # Obtain the geology dataset
+                geology_dataset_id = self.get_parameter("liquefaction_geology_dataset_id")
+
+                if geology_dataset_id is not None:
+                    fragility_sets_liq = self.fragilitysvc.match_inventory( self.get_input_dataset("dfr3_mapping_set"),
+                                                                            epfs, liquefaction_fragility_key)
+
+                    if fragility_sets_liq is not None:
+                        liquefaction_available = True
+
         values_payload = []
+        values_payload_liq = []
         unmapped_epfs = []
         mapped_epfs = []
         for epf in epfs:
@@ -148,6 +158,17 @@ class EpfDamage(BaseAnalysis):
                 }
                 values_payload.append(value)
                 mapped_epfs.append(epf)
+
+                if liquefaction_available and epf["id"] in fragility_sets_liq:
+                    fragility_set_liq = fragility_sets_liq[epf["id"]]
+                    demands_liq = fragility_set_liq.demand_types
+                    units_liq = fragility_set_liq.demand_units
+                    value_liq = {
+                        "demands": demands_liq,
+                        "units": units_liq,
+                        "loc": loc
+                    }
+                    values_payload_liq.append(value_liq)
             else:
                 unmapped_epfs.append(epf)
 
@@ -162,6 +183,12 @@ class EpfDamage(BaseAnalysis):
             hazard_vals = self.hazardsvc.post_tsunami_hazard_values(hazard_dataset_id, values_payload)
         else:
             raise ValueError("Missing hazard type.")
+
+        liquefaction_resp = None
+        if liquefaction_available:
+            liquefaction_resp = self.hazardsvc.post_liquefaction_values(hazard_dataset_id,
+                                                                        geology_dataset_id,
+                                                                        values_payload_liq)
 
         ds_results = []
         damage_results = []
@@ -187,13 +214,38 @@ class EpfDamage(BaseAnalysis):
                 limit_states = selected_fragility_set.calculate_limit_state(hval_dict,
                                                                             inventory_type='electric_facility',
                                                                             **epf_args)
+
+                if liquefaction_resp is not None:
+                    fragility_set_liq = fragility_sets_liq[epf["id"]]
+
+                    if isinstance(fragility_set_liq.fragility_curves[0], FragilityCurve):
+                        liq_hazard_vals = AnalysisUtil.update_precision_of_lists(liquefaction_resp[i]["pgdValues"])
+                        liq_demand_types = liquefaction_resp[i]["demands"]
+                        liq_demand_units = liquefaction_resp[i]["units"]
+                        liquefaction_prob = liquefaction_resp[i]['liqProbability']
+
+                        hval_dict_liq = dict()
+
+                        for j, d in enumerate(fragility_set_liq.demand_types):
+                            hval_dict_liq[d] = liq_hazard_vals[j]
+
+                        facility_liq_args = fragility_set_liq.construct_expression_args_from_inventory(epf)
+                        pgd_limit_states = \
+                            fragility_set_liq.calculate_limit_state(
+                                hval_dict_liq, inventory_type="electric_facility",
+                                **facility_liq_args)
+                    else:
+                        raise ValueError("One of the fragilities is in deprecated format. "
+                                         "This should not happen If you are seeing this please report the issue.")
+
+                    limit_states = AnalysisUtil.adjust_limit_states_for_pgd(limit_states, pgd_limit_states)
+
+                dmg_interval = selected_fragility_set.calculate_damage_interval(limit_states,
+                                                                       hazard_type=hazard_type,
+                                                                       inventory_type='electric_facility')
             else:
                 raise ValueError("One of the fragilities is in deprecated format. This should not happen. If you are "
                                  "seeing this please report the issue.")
-
-            dmg_interval = selected_fragility_set.calculate_damage_interval(limit_states,
-                                                                            hazard_type=hazard_type,
-                                                                            inventory_type="electric_facility")
 
             ds_result["guid"] = epf["properties"]["guid"]
             ds_result.update(limit_states)
@@ -205,11 +257,21 @@ class EpfDamage(BaseAnalysis):
             damage_result["demandtypes"] = input_demand_types
             damage_result["demandunits"] = input_demand_units
             damage_result["hazardtype"] = hazard_type
-            damage_result["hazardval"] = hazard_val
-            damage_result['liq_fragility_id'] = None
-            damage_result['liqhaztype'] = None
-            damage_result['liqhazval'] = None
-            damage_result['liqprobability'] = None
+            damage_result["hazardvals"] = hazard_val
+
+            if hazard_type == "earthquake" and use_liquefaction is True:
+                if liquefaction_available:
+                    damage_result['liq_fragility_id'] = fragility_sets_liq[epf["id"]].id
+                    damage_result['liqdemandtypes'] = liq_demand_types
+                    damage_result['liqdemandunits'] = liq_demand_units
+                    damage_result['liqhazval'] = liq_hazard_vals
+                    damage_result['liqprobability'] = liquefaction_prob
+                else:
+                    damage_result['liq_fragility_id'] = None
+                    damage_result['liqdemandtypes'] = None
+                    damage_result['liqdemandunits'] = None
+                    damage_result['liqhazval'] = None
+                    damage_result['liqprobability'] = None
 
             ds_results.append(ds_result)
             damage_results.append(damage_result)
@@ -217,75 +279,6 @@ class EpfDamage(BaseAnalysis):
             i += 1
 
         #############################################################
-        # when there is liquefaction, limit state need to be modified
-        if hazard_type == 'earthquake' and use_liquefaction and liq_geology_dataset_id is not None:
-            liq_fragility_key = self.get_parameter("liquefaction_fragility_key")
-            if liq_fragility_key is None:
-                liq_fragility_key = self.DEFAULT_LIQ_FRAGILITY_KEY
-            liq_fragility_set = self.fragilitysvc.match_inventory(self.get_input_dataset("dfr3_mapping_set"),
-                                                                  epfs, liq_fragility_key)
-
-            liq_values_payload = []
-            for epf in epfs:
-                epf_id = epf["id"]
-                if epf_id in liq_fragility_set:
-                    location = GeoUtil.get_location(epf)
-                    liq_loc = str(location.y) + "," + str(location.x)
-                    liq_demands = liq_fragility_set[epf_id].demand_types
-                    liq_units = liq_fragility_set[epf_id].demand_units
-                    value = {
-                        "demands": liq_demands,
-                        "units": liq_units,
-                        "loc": liq_loc
-                    }
-                    liq_values_payload.append(value)
-
-            liquefaction_vals = self.hazardsvc.post_liquefaction_values(hazard_dataset_id,
-                                                                        geology_dataset_id=liq_geology_dataset_id,
-                                                                        payload=liq_values_payload)
-
-            i = 0
-            for liq_epf in epfs:
-                liq_epf_id = liq_epf["id"]
-                liq_input_demand_types = liquefaction_vals[i]["demands"][0]
-                liq_hazard_val = AnalysisUtil.update_precision(liquefaction_vals[i][liq_input_demand_types][0])
-                std_dev = 0.0
-                if use_hazard_uncertainty:
-                    raise ValueError("Uncertainty Not Implemented!")
-
-                liquefaction_prob = liquefaction_vals[i]['liqProbability']
-
-                selected_liq_fragility = liq_fragility_set[liq_epf_id]
-                pgd_limit_states = \
-                    selected_liq_fragility.calculate_limit_state_w_conversion(liq_hazard_val, std_dev=std_dev)
-
-                # match id and add liqhaztype, liqhazval, liqprobability field as well as rewrite limit
-                # states and dmg_interval
-                for ds_result in ds_results:
-                    if ds_result['guid'] == liq_epf["properties"]['guid']:
-                        # default EPF to be 4 ls and 5 ds
-                        if ['LS_0', 'LS_1', 'LS_2', 'LS_3'] in ds_result.keys():
-                            limit_states = {"LS_0": ds_result['LS_0'],
-                                            "LS_1": ds_result['LS_1'],
-                                            "LS_2": ds_result['LS_2'],
-                                            "LS_3": ds_result['LS_3']}
-                        else:
-                            raise ValueError("Do not support the limit state name")
-
-                        liq_limit_states = AnalysisUtil.adjust_limit_states_for_pgd(limit_states, pgd_limit_states)
-                        liq_dmg_interval = AnalysisUtil.calculate_damage_interval(liq_limit_states)
-
-                        ds_result.update(liq_limit_states)
-                        ds_result.update(liq_dmg_interval)
-
-                for damage_result in damage_results:
-                    if damage_result['guid'] == liq_epf["properties"]['guid']:
-                        damage_result['liq_fragility_id'] = liq_fragility_set.id
-                        damage_result['liqhaztype'] = liq_input_demand_types
-                        damage_result['liqhazval'] = liq_hazard_val
-                        damage_result['liqprobability'] = liquefaction_prob
-
-                i = i + 1
 
         # unmapped
         for epf in unmapped_epfs:
@@ -298,10 +291,12 @@ class EpfDamage(BaseAnalysis):
             damage_result['demandunits'] = None
             damage_result["hazardtype"] = None
             damage_result['hazardval'] = None
-            damage_result['liq_fragility_id'] = None
-            damage_result['liqhaztype'] = None
-            damage_result['liqhazval'] = None
-            damage_result['liqprobability'] = None
+            if hazard_type == "earthquake" and use_liquefaction is True:
+                damage_result['liq_fragility_id'] = None
+                damage_result['liqdemandtypes'] = None
+                damage_result['liqdemandunits'] = None
+                damage_result['liqhazval'] = None
+                damage_result['liqprobability'] = None
 
             ds_results.append(ds_result)
             damage_results.append(damage_result)
@@ -342,6 +337,12 @@ class EpfDamage(BaseAnalysis):
                     'id': 'fragility_key',
                     'required': False,
                     'description': 'Fragility key to use in mapping dataset ()',
+                    'type': str
+                },
+                {
+                    'id': 'liquefaction_fragility_key',
+                    'required': False,
+                    'description': 'Fragility key to use in liquefaction mapping dataset',
                     'type': str
                 },
                 {

--- a/pyincore/utils/analysisutil.py
+++ b/pyincore/utils/analysisutil.py
@@ -69,27 +69,6 @@ class AnalysisUtil:
     def float_dict_to_decimal(num_dict: dict):
         return {key: Decimal(str(num_dict[key])) for key in num_dict}
 
-    @staticmethod
-    @deprecated(version="0.9.0", reason="Use calculate_damage_interval in fragilitycurveset class instead.")
-    def calculate_damage_interval(damage):
-        output = collections.OrderedDict()
-
-        # convert damage to decimal dictionary
-        damage = AnalysisUtil.float_dict_to_decimal(damage)
-
-        if len(damage) == 4:
-            output['ds-none'] = 1 - damage['ls-slight']
-            output['ds-slight'] = damage['ls-slight'] - damage['ls-moderat']
-            output['ds-moderat'] = damage['ls-moderat'] - damage['ls-extensi']
-            output['ds-extensi'] = damage['ls-extensi'] - damage['ls-complet']
-            output['ds-complet'] = damage['ls-complet']
-        elif len(damage) == 3:
-            output['insignific'] = 1 - damage['immocc']
-            output['moderate'] = damage['immocc'] - damage['lifesfty']
-            output['heavy'] = damage['lifesfty'] - damage['collprev']
-            output['complete'] = damage['collprev']
-
-        return output
 
     @staticmethod
     def calculate_mean_damage(dmg_ratio_tbl, dmg_intervals,
@@ -251,12 +230,10 @@ class AnalysisUtil:
             adj_limit_states = collections.OrderedDict()
 
             for key, value in limit_states.items():
-                adj_limit_states[key] = limit_states[key] + pgd_limit_states[
-                    key] - \
-                                        (limit_states[key] * pgd_limit_states[
-                                            key])
+                adj_limit_states[key] = limit_states[key] + pgd_limit_states[key] - \
+                                        (limit_states[key] * pgd_limit_states[key])
 
-            return adj_limit_states
+            return AnalysisUtil.update_precision_of_dicts(adj_limit_states)
 
         except KeyError as e:
             print('Mismatched keys encountered in the limit states')

--- a/tests/pyincore/analyses/epfdamage/test_epfdamage.py
+++ b/tests/pyincore/analyses/epfdamage/test_epfdamage.py
@@ -6,83 +6,62 @@ import pyincore.globals as pyglobals
 def run_with_base_class():
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
 
+    # ## Memphis EPF Damage with Earthquake ##
     hazard_type_eq = "earthquake"
+    hazard_id_eq = "5b902cb273c3371e1236b36b"
+    epf_dataset_id = "6189c103d5b02930aa3efc35"
+    # mapping_id = "61980b11e32da63f4b9d86f4"
+    mapping_id = "61980cf5e32da63f4b9d86f5"  # PGA and PGD
 
+    use_liquefaction = True
+    use_hazard_uncertainty = False
+    liquefaction_geology_dataset_id = "5a284f53c7d30d13bc08249c"
+
+    # Run epf damage
+    epf_dmg_eq_memphis = EpfDamage(client)
+    epf_dmg_eq_memphis.load_remote_input_dataset("epfs", epf_dataset_id)
+
+    # Load fragility mapping
+    fragility_service = FragilityService(client)
+    mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
+    epf_dmg_eq_memphis.set_input_dataset('dfr3_mapping_set', mapping_set)
+
+    epf_dmg_eq_memphis.set_parameter("result_name", "memphis_eq_epf_dmg_result")
+    epf_dmg_eq_memphis.set_parameter("hazard_type", hazard_type_eq)
+    epf_dmg_eq_memphis.set_parameter("hazard_id", hazard_id_eq)
+    epf_dmg_eq_memphis.set_parameter("use_liquefaction", use_liquefaction)
+    epf_dmg_eq_memphis.set_parameter("use_hazard_uncertainty", use_hazard_uncertainty)
+    epf_dmg_eq_memphis.set_parameter("liquefaction_geology_dataset_id", liquefaction_geology_dataset_id)
+    epf_dmg_eq_memphis.set_parameter("num_cpu", 1)
+    # Run Analysis
+    epf_dmg_eq_memphis.run_analysis()
+
+    # ##  Seaside EPF Damage with Earthquake ##
+    hazard_type_eq = "earthquake"
     hazard_id_eq = "5eebcbb08f80fe3899ad6039"
-
     epf_dataset_id = "5eebcaa17a00803abc85ec11"
-
     # Earthquake mapping
-    mapping_id = "5eebcc13e7226233ce4ef0d7"
+    mapping_id = "5eebcc13e7226233ce4ef0d7"  # only PGA
 
     # Run epf damage
     epf_dmg_eq = EpfDamage(client)
-
     epf_dmg_eq.load_remote_input_dataset("epfs", epf_dataset_id)
 
     # Load fragility mapping
     fragility_service = FragilityService(client)
     mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
     epf_dmg_eq.set_input_dataset('dfr3_mapping_set', mapping_set)
-
-    epf_dmg_eq.set_parameter("result_name", "earthquake_epf_dmg_result")
+    
+    epf_dmg_eq.set_parameter("result_name", "seaside_eq_epf_dmg_result")
     epf_dmg_eq.set_parameter("hazard_type", hazard_type_eq)
     epf_dmg_eq.set_parameter("hazard_id", hazard_id_eq)
     epf_dmg_eq.set_parameter("num_cpu", 1)
-
     # Run Analysis
     epf_dmg_eq.run_analysis()
 
+    # ## Seaside Tsunami EPF Damage ##
     hazard_type_tsu = "tsunami"
     hazard_id_tsu = "5bc9eaf7f7b08533c7e610e1"
-
-    epf_dataset_id = "5eebcaa17a00803abc85ec11"
-
-    # Tsunami mapping
-    mapping_id = "5eebce11e7226233ce4ef305"
-
-    # Run epf damage
-    epf_dmg_tsu = EpfDamage(client)
-    epf_dmg_tsu.load_remote_input_dataset("epfs", epf_dataset_id)
-
-    # Load fragility mapping
-    fragility_service = FragilityService(client)
-    mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
-    epf_dmg_tsu.set_input_dataset('dfr3_mapping_set', mapping_set)
-
-    epf_dmg_tsu.set_parameter("fragility_key", "Non-Retrofit inundationDepth Fragility ID Code")
-    epf_dmg_tsu.set_parameter("result_name", "tsunami_epf_dmg_result")
-    epf_dmg_tsu.set_parameter("hazard_type", hazard_type_tsu)
-    epf_dmg_tsu.set_parameter("hazard_id", hazard_id_tsu)
-    epf_dmg_tsu.set_parameter("num_cpu", 1)
-
-    # Run Analysis
-    epf_dmg_tsu.run_analysis()
-
-    ##################################
-    # test refactored
-
-    # Earthquake mapping
-    mapping_id = "605bf99b618178207f64754b"
-
-    # Run epf damage
-    epf_dmg_eq_re = EpfDamage(client)
-
-    epf_dmg_eq_re.load_remote_input_dataset("epfs", epf_dataset_id)
-
-    # Load fragility mapping
-    fragility_service = FragilityService(client)
-    mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
-    epf_dmg_eq_re.set_input_dataset('dfr3_mapping_set', mapping_set)
-
-    epf_dmg_eq_re.set_parameter("result_name", "refactored_earthquake_epf_dmg_result")
-    epf_dmg_eq_re.set_parameter("hazard_type", hazard_type_eq)
-    epf_dmg_eq_re.set_parameter("hazard_id", hazard_id_eq)
-    epf_dmg_eq_re.set_parameter("num_cpu", 1)
-
-    # Run Analysis
-    epf_dmg_eq_re.run_analysis()
-
     epf_dataset_id = "5eebcaa17a00803abc85ec11"
     # Tsunami mapping
     mapping_id = "605bf9e1618178207f6475c6"
@@ -90,6 +69,8 @@ def run_with_base_class():
     # Run epf damage
     epf_dmg_tsu_re = EpfDamage(client)
     epf_dmg_tsu_re.load_remote_input_dataset("epfs", epf_dataset_id)
+    epf_dmg_eq = EpfDamage(client)
+    epf_dmg_eq.load_remote_input_dataset("epfs", epf_dataset_id)
 
     # Load fragility mapping
     fragility_service = FragilityService(client)
@@ -97,11 +78,12 @@ def run_with_base_class():
     epf_dmg_tsu_re.set_input_dataset('dfr3_mapping_set', mapping_set)
 
     epf_dmg_tsu_re.set_parameter("fragility_key", "Non-Retrofit inundationDepth Fragility ID Code")
-    epf_dmg_tsu_re.set_parameter("result_name", "refactored_tsunami_epf_dmg_result")
+    epf_dmg_tsu_re.set_parameter("result_name", "seaside_tsunami_epf_dmg_result")
     epf_dmg_tsu_re.set_parameter("hazard_type", hazard_type_tsu)
     epf_dmg_tsu_re.set_parameter("hazard_id", hazard_id_tsu)
     epf_dmg_tsu_re.set_parameter("num_cpu", 1)
 
+    epf_dmg_tsu_re.set_input_dataset('dfr3_mapping_set', mapping_set)
     # Run Analysis
     epf_dmg_tsu_re.run_analysis()
 


### PR DESCRIPTION
See the #32 for more details of the task. It handles the below:
1. Fix the broken liquefaction logic on EPF Damage
2. Add test for liquefaction, remove "refactored" test because they are not needed any more
3. Remove deprecated LS/DS name specific method
4. Use 10 digit precision when adjusting PGD limit states

Use the test_epfddamage.py to test