### PR TITLE
#69: Refactoring of DFR3 service to fix the broken fragility functions

### DIFF
--- a/pyincore/__init__.py
+++ b/pyincore/__init__.py
@@ -24,7 +24,7 @@ from pyincore.utils.popdisloutputprocess import PopDislOutputProcess
 from pyincore.utils.cgeoutputprocess import CGEOutputProcess
 from pyincore.dataset import Dataset, InventoryDataset, DamageRatioDataset
 from pyincore.models.fragilitycurveset import FragilityCurveSet
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 from pyincore.models.mappingset import MappingSet
 from pyincore.models.mapping import Mapping
 from pyincore.networkdata import NetworkData

--- a/pyincore/analyses/bridgedamage/bridgedamage.py
+++ b/pyincore/analyses/bridgedamage/bridgedamage.py
@@ -13,7 +13,7 @@ import copy
 from pyincore import AnalysisUtil, GeoUtil
 from pyincore import BaseAnalysis, HazardService, FragilityService
 from pyincore.analyses.bridgedamage.bridgeutil import BridgeUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class BridgeDamage(BaseAnalysis):
@@ -175,7 +175,7 @@ class BridgeDamage(BaseAnalysis):
             dmg_intervals = dict()
             selected_fragility_set = fragility_set[bridge["id"]]
 
-            if isinstance(selected_fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(selected_fragility_set.fragility_curves[0], DFR3Curve):
                 # Supports multiple demand types in same fragility
                 hazard_val = AnalysisUtil.update_precision_of_lists(hazard_vals[i]["hazardValues"])
                 input_demand_types = hazard_vals[i]["demands"]

--- a/pyincore/analyses/buildingdamage/buildingdamage.py
+++ b/pyincore/analyses/buildingdamage/buildingdamage.py
@@ -11,7 +11,7 @@ from itertools import repeat
 from pyincore import BaseAnalysis, HazardService, \
     FragilityService, AnalysisUtil, GeoUtil
 from pyincore.analyses.buildingdamage.buildingutil import BuildingUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class BuildingDamage(BaseAnalysis):
@@ -171,7 +171,7 @@ class BuildingDamage(BaseAnalysis):
             selected_fragility_set = fragility_sets[b_id]
 
             # TODO: Once all fragilities are migrated to new format, we can remove this condition
-            if isinstance(selected_fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(selected_fragility_set.fragility_curves[0], DFR3Curve):
                 # Supports multiple demand types in same fragility
                 b_haz_vals = AnalysisUtil.update_precision_of_lists(hazard_vals[i]["hazardValues"])
                 b_demands = hazard_vals[i]["demands"]
@@ -190,7 +190,7 @@ class BuildingDamage(BaseAnalysis):
                     building_args = selected_fragility_set.construct_expression_args_from_inventory(b)
 
                     building_period = selected_fragility_set.fragility_curves[0].get_building_period(
-                        selected_fragility_set.fragility_curve_parameters, **building_args)
+                        selected_fragility_set.curve_parameters, **building_args)
 
                     dmg_probability = selected_fragility_set.calculate_limit_state(
                         hval_dict, **building_args, period=building_period)

--- a/pyincore/analyses/epfdamage/epfdamage.py
+++ b/pyincore/analyses/epfdamage/epfdamage.py
@@ -9,7 +9,7 @@ from itertools import repeat
 
 from pyincore import AnalysisUtil, GeoUtil
 from pyincore import BaseAnalysis, HazardService, FragilityService
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class EpfDamage(BaseAnalysis):
@@ -199,7 +199,7 @@ class EpfDamage(BaseAnalysis):
             damage_result = dict()
             selected_fragility_set = fragility_set[epf["id"]]
 
-            if isinstance(selected_fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(selected_fragility_set.fragility_curves[0], DFR3Curve):
                 hazard_val = AnalysisUtil.update_precision_of_lists(hazard_vals[i]["hazardValues"])
                 input_demand_types = hazard_vals[i]["demands"]
                 input_demand_units = hazard_vals[i]["units"]
@@ -218,7 +218,7 @@ class EpfDamage(BaseAnalysis):
                 if liquefaction_resp is not None:
                     fragility_set_liq = fragility_sets_liq[epf["id"]]
 
-                    if isinstance(fragility_set_liq.fragility_curves[0], FragilityCurve):
+                    if isinstance(fragility_set_liq.fragility_curves[0], DFR3Curve):
                         liq_hazard_vals = AnalysisUtil.update_precision_of_lists(liquefaction_resp[i]["pgdValues"])
                         liq_demand_types = liquefaction_resp[i]["demands"]
                         liq_demand_units = liquefaction_resp[i]["units"]

--- a/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
+++ b/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
@@ -10,7 +10,7 @@ from pyincore import AnalysisUtil, GeoUtil
 from pyincore import BaseAnalysis, HazardService, FragilityService
 from pyincore.analyses.nonstructbuildingdamage.nonstructbuildingutil import \
     NonStructBuildingUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class NonStructBuildingDamage(BaseAnalysis):
@@ -203,7 +203,7 @@ class NonStructBuildingDamage(BaseAnalysis):
 
             ###############
             # AS
-            if isinstance(fragility_set_as.fragility_curves[0], FragilityCurve):
+            if isinstance(fragility_set_as.fragility_curves[0], DFR3Curve):
                 hazard_vals_as = AnalysisUtil.update_precision_of_lists(hazard_resp_as[i]["hazardValues"])
                 demand_types_as = hazard_resp_as[i]["demands"]
                 demand_units_as = hazard_resp_as[i]["units"]
@@ -232,7 +232,7 @@ class NonStructBuildingDamage(BaseAnalysis):
 
             ###############
             # DS
-            if isinstance(fragility_set_ds.fragility_curves[0], FragilityCurve):
+            if isinstance(fragility_set_ds.fragility_curves[0], DFR3Curve):
                 hazard_vals_ds = AnalysisUtil.update_precision_of_lists(hazard_resp_ds[i]["hazardValues"])
                 demand_types_ds = hazard_resp_ds[i]["demands"]
                 demand_units_ds = hazard_resp_ds[i]["units"]

--- a/pyincore/analyses/pipelinedamage/pipelinedamage.py
+++ b/pyincore/analyses/pipelinedamage/pipelinedamage.py
@@ -12,7 +12,7 @@ from itertools import repeat
 
 from pyincore import BaseAnalysis, HazardService, FragilityService, \
     FragilityCurveSet, AnalysisUtil, GeoUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class PipelineDamage(BaseAnalysis):
@@ -162,7 +162,7 @@ class PipelineDamage(BaseAnalysis):
             fragility_set = fragility_sets[pipeline["id"]]
 
             # TODO: Once all fragilities are migrated to new format, we can remove this condition
-            if isinstance(fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(fragility_set.fragility_curves[0], DFR3Curve):
                 # Supports multiple demand types in same fragility
                 haz_vals = AnalysisUtil.update_precision_of_lists(hazard_vals[i]["hazardValues"])
                 demand_types = hazard_vals[i]["demands"]

--- a/pyincore/analyses/pipelinedamagerepairrate/pipelinedamagerepairrate.py
+++ b/pyincore/analyses/pipelinedamagerepairrate/pipelinedamagerepairrate.py
@@ -18,7 +18,7 @@ from pyincore import BaseAnalysis, HazardService, FragilityService, \
     AnalysisUtil, GeoUtil
 from pyincore.analyses.pipelinedamagerepairrate.pipelineutil import \
     PipelineUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class PipelineDamageRepairRate(BaseAnalysis):
@@ -226,7 +226,7 @@ class PipelineDamageRepairRate(BaseAnalysis):
             fragility_curve = fragility_set.fragility_curves[0]
 
             # TODO: Once all fragilities are migrated to new format, we can remove this condition
-            if isinstance(fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(fragility_set.fragility_curves[0], DFR3Curve):
                 hazard_vals = AnalysisUtil.update_precision_of_lists(hazard_resp[i]["hazardValues"])
                 demand_types = hazard_resp[i]["demands"]
                 demand_units = hazard_resp[i]["units"]
@@ -239,7 +239,7 @@ class PipelineDamageRepairRate(BaseAnalysis):
                     pipeline_args = fragility_set.construct_expression_args_from_inventory(pipeline)
                     pgv_repairs = \
                         fragility_curve.calculate_limit_state_probability(
-                            hval_dict, fragility_set.fragility_curve_parameters, **pipeline_args)
+                            hval_dict, fragility_set.curve_parameters, **pipeline_args)
                     # Convert PGV repairs to SI units
                     pgv_repairs = PipelineUtil.convert_result_unit(fragility_curve.return_type["unit"], pgv_repairs)
 
@@ -254,7 +254,7 @@ class PipelineDamageRepairRate(BaseAnalysis):
                         liq_fragility_curve = fragility_set_liq.fragility_curves[0]
 
                         # TODO: Once all fragilities are migrated to new format, we can remove this condition
-                        if isinstance(fragility_set_liq.fragility_curves[0], FragilityCurve):
+                        if isinstance(fragility_set_liq.fragility_curves[0], DFR3Curve):
                             liq_hazard_vals = AnalysisUtil.update_precision_of_lists(liquefaction_resp[i]["pgdValues"])
                             liq_demand_types = liquefaction_resp[i]["demands"]
                             liq_demand_units = liquefaction_resp[i]["units"]
@@ -268,7 +268,7 @@ class PipelineDamageRepairRate(BaseAnalysis):
                             pipeline_args = fragility_set_liq.construct_expression_args_from_inventory(pipeline)
                             pgd_repairs = \
                                 liq_fragility_curve.calculate_limit_state_probability(
-                                    liq_hval_dict, fragility_set_liq.fragility_curve_parameters, **pipeline_args)
+                                    liq_hval_dict, fragility_set_liq.curve_parameters, **pipeline_args)
                             # Convert PGD repairs to SI units
                             pgd_repairs = PipelineUtil.convert_result_unit(liq_fragility_curve.return_type["unit"],
                                                                            pgd_repairs)

--- a/pyincore/analyses/roaddamage/roaddamage.py
+++ b/pyincore/analyses/roaddamage/roaddamage.py
@@ -9,7 +9,7 @@ import concurrent.futures
 from itertools import repeat
 
 from pyincore import BaseAnalysis, HazardService, FragilityService, AnalysisUtil, GeoUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class RoadDamage(BaseAnalysis):
@@ -191,7 +191,7 @@ class RoadDamage(BaseAnalysis):
             if use_hazard_uncertainty:
                 raise ValueError("Uncertainty Not Implemented Yet.")
 
-            if isinstance(selected_fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(selected_fragility_set.fragility_curves[0], DFR3Curve):
                 hazard_vals = AnalysisUtil.update_precision_of_lists(hazard_resp[i]["hazardValues"])
                 demand_types = hazard_resp[i]["demands"]
                 demand_units = hazard_resp[i]["units"]

--- a/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
+++ b/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
@@ -15,7 +15,7 @@ from shapely.geometry import shape
 
 from pyincore import BaseAnalysis, HazardService, FragilityService, DataService, FragilityCurveSet
 from pyincore import GeoUtil, NetworkUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class TornadoEpnDamage(BaseAnalysis):
@@ -305,7 +305,7 @@ class TornadoEpnDamage(BaseAnalysis):
                                         hval_dict[d] = tor_hazard_values[j]
                                         j += 1
                                     if isinstance(fragility_set_used.fragility_curves[0],
-                                                  FragilityCurve):
+                                                  DFR3Curve):
                                         inventory_args = fragility_set_used.construct_expression_args_from_inventory(
                                             tornado_feature)
                                         resistivity_probability = \

--- a/pyincore/analyses/waterfacilitydamage/waterfacilitydamage.py
+++ b/pyincore/analyses/waterfacilitydamage/waterfacilitydamage.py
@@ -14,7 +14,7 @@ from itertools import repeat
 
 from pyincore import BaseAnalysis, HazardService, FragilityService, GeoUtil, \
     AnalysisUtil
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 
 
 class WaterFacilityDamage(BaseAnalysis):
@@ -241,7 +241,7 @@ class WaterFacilityDamage(BaseAnalysis):
             if uncertainty:
                 hazard_std_dev = random.random()
 
-            if isinstance(fragility_set.fragility_curves[0], FragilityCurve):
+            if isinstance(fragility_set.fragility_curves[0], DFR3Curve):
                 hazard_vals = AnalysisUtil.update_precision_of_lists(hazard_resp[i]["hazardValues"])
                 demand_types = hazard_resp[i]["demands"]
                 demand_units = hazard_resp[i]["units"]
@@ -262,7 +262,7 @@ class WaterFacilityDamage(BaseAnalysis):
                     if liquefaction_resp is not None:
                         fragility_set_liq = fragility_sets_liq[facility["id"]]
 
-                        if isinstance(fragility_set_liq.fragility_curves[0], FragilityCurve):
+                        if isinstance(fragility_set_liq.fragility_curves[0], DFR3Curve):
                             liq_hazard_vals = AnalysisUtil.update_precision_of_lists(liquefaction_resp[i]["pgdValues"])
                             liq_demand_types = liquefaction_resp[i]["demands"]
                             liq_demand_units = liquefaction_resp[i]["units"]

--- a/pyincore/models/dfr3curve.py
+++ b/pyincore/models/dfr3curve.py
@@ -13,8 +13,8 @@ from pyincore.utils import evaluateexpression
 logger = pyglobals.LOGGER
 
 
-class FragilityCurve(ABC):
-    """A class to represent conditional standard fragility curve."""
+class DFR3Curve:
+    """A class to represent a DFR3 curve."""
 
     def __init__(self, curve_parameters):
         self.rules = curve_parameters['rules']
@@ -24,12 +24,12 @@ class FragilityCurve(ABC):
             rule["expression"] = rule["expression"].replace("^", "**")
         self.description = curve_parameters['description']
 
-    def calculate_limit_state_probability(self, hazard_values: dict, fragility_curve_parameters: dict, **kwargs):
+    def calculate_limit_state_probability(self, hazard_values: dict, curve_parameters: dict, **kwargs):
         """Computes limit state probabilities.
 
         Args:
             hazard_values (dict): Hazard values.
-            fragility_curve_parameters (dict): Fragility curve parameters.
+            curve_parameters (dict): Fragility curve parameters.
             **kwargs: Keyword arguments.
 
         Returns:
@@ -42,7 +42,7 @@ class FragilityCurve(ABC):
         # 1. Figure out if parameter name needs to be mapped (i.e. the name contains forbidden characters)
         # 2. Fetch all parameters listed in the curve from kwargs and if there are not in kwargs, use default values
         # from the curve.
-        for parameter in fragility_curve_parameters:
+        for parameter in curve_parameters:
             # if default exists, use default
             if "expression" in parameter and parameter["expression"] is not None:
                 parameters[parameter["name"]] = evaluateexpression.evaluate(parameter["expression"], parameters)
@@ -101,12 +101,12 @@ class FragilityCurve(ABC):
 
         return probability
 
-    def get_building_period(self, fragility_curve_parameters, **kwargs):
+    def get_building_period(self, curve_parameters, **kwargs):
         """
                 Get building period from the fragility curve.
 
         Args:
-            fragility_curve_parameters (dict): Fragility curve parameters.
+            curve_parameters (dict): Fragility curve parameters.
             **kwargs: Keyword arguments.
 
         Returns:
@@ -116,7 +116,7 @@ class FragilityCurve(ABC):
 
         period = 0.0
         num_stories = 1.0
-        for parameter in fragility_curve_parameters:
+        for parameter in curve_parameters:
             # if default exists, use default
             if parameter["name"] == "num_stories" and "expression" in parameter and parameter["expression"] is not None:
                 num_stories = evaluateexpression.evaluate(parameter["expression"])

--- a/pyincore/models/fragilitycurveset.py
+++ b/pyincore/models/fragilitycurveset.py
@@ -6,7 +6,7 @@
 
 import json
 
-from pyincore.models.fragilitycurve import FragilityCurve
+from pyincore.models.dfr3curve import DFR3Curve
 from pyincore.utils.analysisutil import AnalysisUtil
 
 
@@ -34,21 +34,17 @@ class FragilityCurveSet:
         self.result_unit = metadata["resultUnit"] if "resultUnit" in metadata else ""
         self.hazard_type = metadata['hazardType']
         self.inventory_type = metadata['inventoryType']
-        self.fragility_curve_parameters = {}
+        self.curve_parameters = {}
         self.fragility_curves = []
 
-        if 'fragilityCurveParameters' in metadata.keys():
-            self.fragility_curve_parameters = metadata["fragilityCurveParameters"]
+        if 'curveParameters' in metadata.keys():
+            self.curve_parameters = metadata["curveParameters"]
 
         if 'fragilityCurves' in metadata.keys():
             for fragility_curve in metadata["fragilityCurves"]:
-                self.fragility_curves.append(FragilityCurve(fragility_curve))
-        elif 'repairCurves' in metadata.keys():
-            self.repairCurves = metadata['repairCurves']
-        elif 'restorationCurves' in metadata.keys():
-            self.restorationCurves = metadata['restorationCurves']
+                self.fragility_curves.append(DFR3Curve(fragility_curve))
         else:
-            raise ValueError("Cannot create dfr3 curve object. Missing key field.")
+            raise ValueError("Cannot create dfr3 curve object. Missing key field: fragilityCurves.")
 
     @classmethod
     def from_json_str(cls, json_str):
@@ -100,7 +96,7 @@ class FragilityCurveSet:
         if len(self.fragility_curves) <= 4:
             for fragility_curve in self.fragility_curves:
                 probability = fragility_curve.calculate_limit_state_probability(hazard_values,
-                                                                                self.fragility_curve_parameters,
+                                                                                self.curve_parameters,
                                                                                 **kwargs)
                 output[limit_state[index]] = AnalysisUtil.update_precision(probability)  # round to default digits
                 index += 1
@@ -224,7 +220,7 @@ class FragilityCurveSet:
 
         """
         kwargs_dict = {}
-        for parameters in self.fragility_curve_parameters:
+        for parameters in self.curve_parameters:
 
             if parameters['name'] == "age_group" and ('age_group' not in inventory_unit['properties'] or \
                                                       inventory_unit['properties']['age_group'] == ""):

--- a/pyincore/utils/analysisutil.py
+++ b/pyincore/utils/analysisutil.py
@@ -380,7 +380,7 @@ class AnalysisUtil:
 
             building_args = fragility_set.construct_expression_args_from_inventory(building)
             building_period = fragility_set.fragility_curves[0].get_building_period(
-                fragility_set.fragility_curve_parameters, **building_args)
+                fragility_set.curve_parameters, **building_args)
 
             if fragility_hazard_type.endswith('sa') and fragility_hazard_type != 'sa':
                 # This fixes a bug where demand type is in a format similar to 1.0 Sec Sa
@@ -444,7 +444,7 @@ class AnalysisUtil:
                 # Get building period from the fragility if possible
                 building_args = fragility_set.construct_expression_args_from_inventory(building)
                 building_period = fragility_set.fragility_curves[0].get_building_period(
-                    fragility_set.fragility_curve_parameters, **building_args)
+                    fragility_set.curve_parameters, **building_args)
 
                 # TODO: There might be a bug here as this is not handling SD
                 if demand_type.endswith('sa'):
@@ -460,7 +460,7 @@ class AnalysisUtil:
                                 building_period = building[PROPERTIES][BLDG_PERIOD]
                             else:
                                 # try to calculate the period from the expression
-                                for param in fragility_set.fragility_curve_parameters:
+                                for param in fragility_set.curve_parameters:
                                     if param["name"].lower() == "period":
                                         # TODO: This is a hack and expects a parameter with name "period" present.
                                         #  This can potentially cause naming conflicts in some fragilities

--- a/tests/data/fragility_curve.json
+++ b/tests/data/fragility_curve.json
@@ -19,7 +19,6 @@
   ],
   "fragilityCurves": [
     {
-      "className": "FragilityCurveRefactored",
       "description": "new schema proposed for parametric fragility curves",
       "rules": [
         {
@@ -40,10 +39,10 @@
         "unit": "",
         "description": "NA"
       },
-      "fragilityCurveParameters": null
+      "curveParameters": null
     }
   ],
-  "fragilityCurveParameters": [
+  "curveParameters": [
     {
       "name": "surgeLevel",
       "unit": "m",

--- a/tests/data/fragility_curves/PeriodStandardFragilityCurve_refactored.json
+++ b/tests/data/fragility_curves/PeriodStandardFragilityCurve_refactored.json
@@ -17,7 +17,6 @@
   "fragilityCurves": [
     {
       "description": "legacy - PeriodStandardFragilityCurve",
-      "className": "FragilityCurveRefactored",
       "returnType": {
         "type": "Limit State",
         "unit": "",
@@ -31,7 +30,6 @@
     },
     {
       "description": "legacy - PeriodStandardFragilityCurve",
-      "className": "FragilityCurveRefactored",
       "returnType": {
         "type": "Limit State",
         "unit": "",
@@ -45,7 +43,6 @@
     },
     {
       "description": "legacy - PeriodStandardFragilityCurve",
-      "className": "FragilityCurveRefactored",
       "returnType": {
         "type": "Limit State",
         "unit": "",
@@ -59,7 +56,7 @@
     }
   ],
   "creator": "incore",
-  "fragilityCurveParameters": [
+  "curveParameters": [
     {
       "name": "point_two_sec_SA",
       "fullName": "0.2 sec Sa",
@@ -78,6 +75,5 @@
       "description": "default building period",
       "expression": "1.08"
     }
-  ],
-  "id": "5b47b2d7337d4a36187c61c9"
+  ]
 }

--- a/tests/data/repairset.json
+++ b/tests/data/repairset.json
@@ -1,46 +1,81 @@
 {
-  "description": "pytest EPN sub-station earthquake repair models",
-  "authors": [
-    "HAZUS"
-  ],
-  "paperReference": null,
-  "resultUnit": null,
-  "resultType": "Limit State",
-  "timeUnits": "days",
-  "hazardType": "earthquake",
-  "inventoryType": "electric_power_facility",
-  "repairCurves": [
-    {
-      "className": "StandardRepairCurve",
-      "description": "Slight",
-      "alpha": 1,
-      "beta": 0.47,
-      "curveType": "LogNormal",
-      "alphaType": "median"
-    },
-    {
-      "className": "StandardRepairCurve",
-      "description": "Moderate",
-      "alpha": 2.7,
-      "beta": 0.47,
-      "curveType": "LogNormal",
-      "alphaType": "median"
-    },
-    {
-      "className": "StandardRepairCurve",
-      "description": "Extensive",
-      "alpha": 6.3,
-      "beta": 0.47,
-      "curveType": "LogNormal",
-      "alphaType": "median"
-    },
-    {
-      "className": "StandardRepairCurve",
-      "description": "Complete",
-      "alpha": 27,
-      "beta": 0.47,
-      "curveType": "LogNormal",
-      "alphaType": "median"
-    }
-  ]
+    "description": "test repair curves",
+    "authors": [],
+    "paperReference": null,
+    "resultUnit": null,
+    "resultType": "repair_rate",
+    "hazardType": "earthquake",
+    "inventoryType": "building",
+    "timeUnits": "weeks",
+   "repairCurves": [
+        {
+            "description": "weekly repair rate - Slight",
+            "rules": [
+                {
+                    "condition": [
+                        "True"
+                    ],
+                    "expression": "scipy.stats.lognorm.ppf(numpy.random.random(size=10), s=0.159, scale=numpy.exp(0.8196))"
+                }
+            ],
+            "returnType": {
+                "type": "Repair Rate",
+                "unit": "",
+                "description": "LS_0"
+            },
+            "curveParameters": null
+        },
+        {
+            "description": "weekly repair rate - Moderate",
+            "rules": [
+                {
+                    "condition": [
+                        "True"
+                    ],
+                    "expression": "scipy.stats.lognorm.ppf(numpy.random.random(size=10), s=10, scale=numpy.exp(0.8196))"
+                }
+            ],
+            "returnType": {
+                "type": "Repair Rate",
+                "unit": "",
+                "description": "LS_1"
+            },
+            "curveParameters": null
+        },
+        {
+            "description": "weekly repair rate - Extensive",
+            "rules": [
+                {
+                    "condition": [
+                        "True"
+                    ],
+                    "expression": "scipy.stats.lognorm.ppf(numpy.random.random(size=10), s=20, scale=numpy.exp(0.8196))"
+                }
+            ],
+            "returnType": {
+                "type": "Repair Rate",
+                "unit": "",
+                "description": "LS_2"
+            },
+            "curveParameters": null
+        },
+        {
+            "description": "weekly repair rate - Complete",
+            "rules": [
+                {
+                    "condition": [
+                        "True"
+                    ],
+                    "expression": "scipy.stats.lognorm.ppf(numpy.random.random(size=10), s=30, scale=numpy.exp(0.8196))"
+                }
+            ],
+            "returnType": {
+                "type": "Repair Rate",
+                "unit": "",
+                "description": "LS_3"
+            },
+            "curveParameters": null
+        }
+    ],
+    "curveParameters": null
 }

--- a/tests/pyincore/models/test_dfr3curve.py
+++ b/tests/pyincore/models/test_dfr3curve.py
@@ -9,7 +9,7 @@ import numpy as np
 
 
 def test_fragility_set_small_overlap():
-    fragility_set = get_fragility_set("refactored_fragility_curve.json")
+    fragility_set = get_fragility_set("fragility_curve.json")
 
     # Test Case 1 - single overlap
     limit_states = collections.OrderedDict([("LS_0", 0.9692754643), ("LS_1", 0.0001444974), ("LS_2", 0.0004277083)])
@@ -44,15 +44,15 @@ def get_remote_fragility_set(fragility_id: str):
 
 
 def test_create_fragility_set():
-    fragility_set = get_fragility_set("refactored_fragility_curve.json")
+    fragility_set = get_fragility_set("fragility_curve.json")
     assert len(fragility_set.fragility_curves) != 0
 
 
 @pytest.mark.parametrize("fragility_set,hazard_values,args,expected", [
-    (get_fragility_set("refactored_fragility_curve.json"), {}, {}, 0.2619967240482869),
-    (get_fragility_set("refactored_fragility_curve.json"), {"surgeLevel": 6, "waveHeight": 4}, {}, 1.0),
-    (get_fragility_set("refactored_fragility_curve.json"), {"waveHeight": 4}, {}, 1.0),
-    (get_fragility_set("refactored_fragility_curve.json"), {"surgeLevel": 6}, {}, 0.9999999950124077),
+    (get_fragility_set("fragility_curve.json"), {}, {}, 0.2619967240482869),
+    (get_fragility_set("fragility_curve.json"), {"surgeLevel": 6, "waveHeight": 4}, {}, 1.0),
+    (get_fragility_set("fragility_curve.json"), {"waveHeight": 4}, {}, 1.0),
+    (get_fragility_set("fragility_curve.json"), {"surgeLevel": 6}, {}, 0.9999999950124077),
     (get_remote_fragility_set("606221fe618178207f6608a1"),
      {"waveHeight": 1.1111, "surgeLevel": 3},
      {"clearance": 4, "span_mass": 12, "g_elev": 0.2},
@@ -72,6 +72,7 @@ def test_create_fragility_set():
 ])
 def test_calculate_limit_state_probability(fragility_set, hazard_values, args, expected):
     result = fragility_set.calculate_limit_state(hazard_values, **args)
+    print(result)
     assert np.isclose(result["LS_0"], expected)
 
 

--- a/tests/pyincore/test_dfr3service.py
+++ b/tests/pyincore/test_dfr3service.py
@@ -95,7 +95,7 @@ def test_get_fragility_mapping(fragilitysvc):
 
 
 def test_create_and_delete_fragility_set(fragilitysvc):
-    with open(os.path.join(pyglobals.TEST_DATA_DIR, "refactored_fragility_curve.json"), 'r') as f:
+    with open(os.path.join(pyglobals.TEST_DATA_DIR, "fragility_curve.json"), 'r') as f:
         fragility_set = json.load(f)
     created = fragilitysvc.create_dfr3_set(fragility_set)
     assert "id" in created.keys()
@@ -134,3 +134,4 @@ def test_get_repair_sets(repairsvc):
     metadata = repairsvc.get_dfr3_sets(hazard_type="earthquake", creator="incrtest")
 
     assert 'id' in metadata[0].keys()
+


### PR DESCRIPTION
- Refactoring of DFR3 service to fix the broken fragility specific pytests and analyses 
- Repair changes are not included, it will be addressed in #71 
- All analyses and pytests should work now, except residentialbuildingrecovery that uses repair curves

Please ignore the inaccurate branch name (even though t says repair-curve-refactoring, this only deals with fragilities and broken repaircurve pytests)