### PR TITLE
78 pipeline restoration analysis

### DIFF
--- a/pyincore/analyses/pipelinerestoration/__init__.py
+++ b/pyincore/analyses/pipelinerestoration/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2019 University of Illinois and others. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License v2.0 which accompanies this distribution,
+# and is available at https://www.mozilla.org/en-US/MPL/2.0/
+
+
+from pyincore.analyses.pipelinerestoration.pipelinerestoration import PipelineRestoration

--- a/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
@@ -188,11 +188,8 @@ class PipelineRestoration(BaseAnalysis):
 
         if 'guid' in dmg.keys():
             res_result['guid'] = dmg['guid']
-
-        elif 'id' in dmg.keys():
-            res_result['id'] = dmg['id']
         else:
-            res_result['id'] = 'NA'
+            res_result['guid'] = 'NA'
 
         res_result['breakrate'] = dmg['breakrate']
         res_result['leakrate'] = dmg['leakrate']

--- a/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
@@ -191,9 +191,6 @@ class PipelineRestoration(BaseAnalysis):
         else:
             res_result['guid'] = 'NA'
 
-        res_result['breakrate'] = dmg['breakrate']
-        res_result['leakrate'] = dmg['leakrate']
-
         res_result['repair_time'] = restoration_set.calculate_restoration_rates(**{
             "break_rate": float(dmg['breakrate']),
             "leak_rate": float(dmg['leakrate']),

--- a/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
@@ -99,7 +99,6 @@ class PipelineRestoration(BaseAnalysis):
         damage_result = pipelines_dmg_df.merge(pipelines_df, on='guid')
         damage_result = damage_result.to_dict(orient='records')
 
-        # setting number of cpus to use
         user_defined_cpu = 1
         if not self.get_parameter("num_cpu") is None and self.get_parameter(
                 "num_cpu") > 0:
@@ -167,11 +166,9 @@ class PipelineRestoration(BaseAnalysis):
         restoration_sets = self.restorationsvc.match_list_of_dicts(self.get_input_dataset("dfr3_mapping_set"),
                                                                    damage, restoration_key)
 
-        i = 0
         for dmg in damage:
             res = self.restoration_time(dmg, num_available_workers, restoration_sets[dmg['guid']])
             restoration_results.append(res)
-            i += 1
 
         return restoration_results
 
@@ -199,14 +196,11 @@ class PipelineRestoration(BaseAnalysis):
 
         res_result['breakrate'] = dmg['breakrate']
         res_result['leakrate'] = dmg['leakrate']
-        res_result['diameter'] = dmg['diameter']
 
         res_result['repair_time'] = restoration_set.calculate_restoration_rates(**{
             "break_rate": float(dmg['breakrate']),
             "leak_rate": float(dmg['leakrate']),
             "pipe_length": dmg['length'],
             "num_workers": num_available_workers})['RT']
-
-        res_result['haz_expose'] = dmg['haz_expose']
 
         return res_result

--- a/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
@@ -202,8 +202,8 @@ class PipelineRestoration(BaseAnalysis):
         res_result['diameter'] = dmg['diameter']
 
         res_result['repair_time'] = restoration_set.calculate_restoration_rates(**{
-            "break_rate": float(dmg['breakrate'])*100,
-            "leak_rate": float(dmg['leakrate'])*100,
+            "break_rate": float(dmg['breakrate']),
+            "leak_rate": float(dmg['leakrate']),
             "pipe_length": dmg['length'],
             "num_workers": num_available_workers})['RT']
 

--- a/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/pipelinerestoration.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2019 University of Illinois and others. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License v2.0 which accompanies this distribution,
+# and is available at https://www.mozilla.org/en-US/MPL/2.0/
+
+
+import collections
+import concurrent.futures
+import pandas as pd
+
+from pyincore import BaseAnalysis, AnalysisUtil, RestorationService
+
+
+class PipelineRestoration(BaseAnalysis):
+    """
+    Args:
+        incore_client (IncoreClient): Service authentication.
+
+    """
+
+    def __init__(self, incore_client):
+        self.restorationsvc = RestorationService(incore_client)
+        super(PipelineRestoration, self).__init__(incore_client)
+
+    def get_spec(self):
+        """Get specifications of the Pipeline Restoration analysis.
+
+        Returns:
+            obj: A JSON object of specifications of the pipeline restoration analysis.
+
+        """
+        return {
+            'name': 'pipeline-restoration',
+            'description': 'calculate the restoration times for damaged pipelines',
+            'input_parameters': [
+                {
+                    'id': 'result_name',
+                    'required': True,
+                    'description': 'name of the result csv dataset',
+                    'type': str
+                },
+                {
+                    'id': 'num_cpu',
+                    'required': False,
+                    'description': 'If using parallel execution, the number of cpus to request',
+                    'type': int
+                },
+                {
+                    'id': 'num_available_workers',
+                    'required': True,
+                    'description': 'Number of available workers to work on the repairs',
+                    'type': int
+                },
+                {
+                    'id': 'restoration_key',
+                    'required': False,
+                    'description': 'restoration key to use in mapping dataset',
+                    'type': str
+                },
+            ],
+            'input_datasets': [
+                {
+                    'id': 'pipeline',
+                    'required': True,
+                    'description': 'Pipeline Inventory',
+                    'type': ['ergo:buriedPipelineTopology', 'ergo:pipeline'],
+                },
+                {
+                    'id': 'pipeline_damage',
+                    'required': True,
+                    'description': 'pipeline damage results with repairs',
+                    'type': ['ergo:pipelineDamageVer2']
+                },
+                {
+                    'id': 'dfr3_mapping_set',
+                    'required': True,
+                    'description': 'DFR3 Mapping Set Object',
+                    'type': ['incore:dfr3MappingSet'],
+                }
+            ],
+            'output_datasets': [
+                {
+                    'id': 'pipeline_restoration',
+                    'description': 'CSV file of pipeline restoration times',
+                    'type': 'incore:pipelineRestorationVer1'
+                }
+            ]
+        }
+
+    def run(self):
+        """Executes pipeline restoration analysis."""
+
+        pipelines_fiona_list = self.get_input_dataset("pipeline").get_inventory_reader()
+        pipelines_df = self.get_input_dataset("pipeline").get_dataframe_from_shapefile()
+
+        pipeline_dmg = self.get_input_dataset("pipeline_damage").get_csv_reader()
+        pipelines_dmg_df = pd.DataFrame(list(pipeline_dmg))
+
+        damage_result = pipelines_dmg_df.merge(pipelines_df, on='guid')
+        # damage_result = damage_result.to_dict()
+
+        # setting number of cpus to use
+        user_defined_cpu = 1
+        if not self.get_parameter("num_cpu") is None and self.get_parameter(
+                "num_cpu") > 0:
+            user_defined_cpu = self.get_parameter("num_cpu")
+
+        num_workers = AnalysisUtil.determine_parallelism_locally(self,
+                                                                 len(
+                                                                     damage_result),
+                                                                 user_defined_cpu)
+
+        avg_bulk_input_size = int(len(damage_result) / num_workers)
+        inventory_args = []
+        count = 0
+        inventory_list = damage_result
+
+        while count < len(inventory_list):
+            inventory_args.append(inventory_list[count:count + avg_bulk_input_size])
+            count += avg_bulk_input_size
+
+        restoration_results = self.pipeline_restoration_concurrent_future(
+            self.pipeline_restoration_bulk_input, num_workers,
+            inventory_args)
+        self.set_result_csv_data("pipeline_restoration",
+                                 restoration_results, name=self.get_parameter("result_name"))
+        return True
+
+    def pipeline_restoration_concurrent_future(self, function_name,
+                                               parallelism, *args):
+        """Utilizes concurrent.future module.
+
+        Args:
+            function_name (function): The function to be parallelized.
+            parallelism (int): Number of workers in parallelization.
+            *args: All the arguments in order to pass into parameter function_name.
+
+        Returns:
+            list: A list of dictionary with restoration details
+
+        """
+        res_output = []
+        with concurrent.futures.ProcessPoolExecutor(
+                max_workers=parallelism) as executor:
+            for res_ret in executor.map(function_name, *args):
+                res_output.extend(res_ret)
+
+        return res_output
+
+    def pipeline_restoration_bulk_input(self, damage):
+        """Run analysis for pipeline restoration calculation
+
+        Args:
+            damage (obj): An output of pipeline damage with repair rate
+
+        Returns:
+            restoration_results (list): A list of dictionary restoration times and inventory details
+
+        """
+        restoration_results = []
+        num_available_workers = self.get_parameter("num_available_workers")
+
+        restoration_key = self.get_parameter("restoration_key")
+        if restoration_key is None:
+            restoration_key = "Restoration ID Code"
+
+        # HACK
+        damage_with_props = []
+        for idx, dmg in damage.iterrows():
+            damage_with_props.append({"properties": dmg})
+
+        # restoration_sets = self.restorationsvc.match_inventory(self.get_input_dataset("dfr3_mapping_set"),
+        #                                                        damage_with_props, restoration_key)
+
+        i = 0
+        for idx, dmg in damage.iterrows():
+            res = self.restoration_time(dmg, num_available_workers)
+            restoration_results.append(res)
+            i += 1
+
+        return restoration_results
+
+    def restoration_time(self, dmg, num_available_workers):
+        """Calculates restoration time for a single pipeline.
+
+        Args:
+            dmg (obj): Pipeline damage analysis output for a single entry.
+            num_available_workers (int): Number of available workers working on the repairs.
+
+        Returns:
+            dict: A dictionary with id/guid and restoration time, along with some inventory metadata
+        """
+        # failure state
+        res_result = collections.OrderedDict()
+
+        # copying guid/id column to the sample damage failure table
+        if 'guid' in dmg.keys():
+            res_result['guid'] = dmg['guid']
+
+        elif 'id' in dmg.keys():
+            res_result['id'] = dmg['id']
+        else:
+            res_result['id'] = 'NA'
+
+        res_result['repair_time'] = "1.5"
+
+        return res_result

--- a/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
+++ b/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
@@ -1,0 +1,36 @@
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License v2.0 which accompanies this distribution,
+# and is available at https://www.mozilla.org/en-US/MPL/2.0/
+
+
+from pyincore import IncoreClient, FragilityService, MappingSet
+from pyincore.analyses.pipelinerestoration import PipelineRestoration
+import pyincore.globals as pyglobals
+
+
+def run_with_base_class():
+    client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
+    client.clear_cache()
+    pipeline_restoration = PipelineRestoration(client)
+
+    # shelby county pipelines
+    pipeline_restoration.load_remote_input_dataset("pipeline", "5a284f28c7d30d13bc081d14")
+    pipeline_restoration.load_remote_input_dataset("pipeline_damage", "61f36023c53b3620b6b614c6")
+
+    # Load fragility mapping
+    fragility_service = FragilityService(client)
+    mapping_set = MappingSet(fragility_service.get_mapping("61f35f09903e515036cee106"))
+    pipeline_restoration.set_input_dataset('dfr3_mapping_set', mapping_set)
+
+    pipeline_restoration.set_parameter("result_name","pipeline_restoration_times")
+
+    pipeline_restoration.set_parameter("restoration_key", "Restoration ID Code")
+    pipeline_restoration.set_parameter("num_available_workers", 4)
+    pipeline_restoration.set_parameter("num_cpu", 1)
+
+    # Run pipeline damage analysis
+    result = pipeline_restoration.run_analysis()
+
+
+if __name__ == "__main__":
+    run_with_base_class()

--- a/pyincore/dfr3service.py
+++ b/pyincore/dfr3service.py
@@ -12,6 +12,7 @@ from typing import Dict
 from pyincore import IncoreClient
 from pyincore.models.fragilitycurveset import FragilityCurveSet
 from pyincore.models.repaircurveset import RepairCurveSet
+from pyincore.models.restorationcurveset import RestorationCurveSet
 from pyincore.models.mappingset import MappingSet
 
 # add more types if needed
@@ -120,6 +121,8 @@ class Dfr3Service:
                 batch_dfr3_sets[id] = FragilityCurveSet(dfr3_set)
             elif instance == 'RepairService':
                 batch_dfr3_sets[id] = RepairCurveSet(dfr3_set)
+            elif instance == 'RestorationService':
+                batch_dfr3_sets[id] = RestorationCurveSet(dfr3_set)
             else:
                 raise ValueError("Only fragility and repair services are currently supported")
 

--- a/pyincore/dfr3service.py
+++ b/pyincore/dfr3service.py
@@ -171,7 +171,7 @@ class Dfr3Service:
 
         Args:
             mapping (obj): MappingSet Object that has the rules and entries.
-            inventories (list): A list of inventories.
+            inventories (list): A list of inventories. Each item is a casted fiona object
             entry_key (str): keys such as PGA, pgd, and etc.
             add_info (None, dict): additional information that used to match rules, e.g. retrofit strategy per building.
 
@@ -232,6 +232,66 @@ class Dfr3Service:
         # replace the curve id in dfr3_sets to the dfr3 curve
         for inventory_id, curve_item in dfr3_sets.items():
             if isinstance(curve_item, FragilityCurveSet):
+                pass
+            elif isinstance(curve_item, str):
+                dfr3_sets[inventory_id] = batch_dfr3_sets[curve_item]
+            else:
+                raise ValueError(
+                    "Cannot realize dfr3_set entry. The entry has to be either remote id string; or dfr3curve object!")
+
+        return dfr3_sets
+
+    def match_list_of_dicts(self, mapping: MappingSet, inventories: list, entry_key: str):
+        """This method is same as match_inventory, except it takes a simple list of dictionaries that contains the items
+        to be mapped in the rules. The match_inventory method takes a list of fiona objects
+
+        Args:
+            mapping (obj): MappingSet Object that has the rules and entries.
+            inventories (list): A list of inventories. Each item of the list is a simple dictionary
+            entry_key (str): keys such as PGA, pgd, and etc.
+
+        Returns:
+             dict: A dictionary of {"inventory id": FragilityCurveSet object}.
+
+        """
+        dfr3_sets = {}
+
+        # loop through inventory to match the rules
+        matched_curve_ids = []
+        for inventory in inventories:
+            for m in mapping.mappings:
+                # for old format rule matching [[]]
+                if isinstance(m.rules, list):
+                    if self._property_match_legacy(rules=m.rules, properties=inventory):
+                        curve = m.entry[entry_key]
+                        dfr3_sets[inventory['id']] = curve
+
+                        # if it's string:id; then need to fetch it from remote and cast to fragility3curve object
+                        if isinstance(curve, str) and curve not in matched_curve_ids:
+                            matched_curve_ids.append(curve)
+
+                        # use the first match
+                        break
+
+                # for new format rule matching {"AND/OR":[]}
+                elif isinstance(m.rules, dict):
+                    if self._property_match(rules=m.rules, properties=inventory):
+                        curve = m.entry[entry_key]
+                        dfr3_sets[inventory['guid']] = curve
+
+                        # if it's string:id; then need to fetch it from remote and cast to fragility3curve object
+                        if isinstance(curve, str) and curve not in matched_curve_ids:
+                            matched_curve_ids.append(curve)
+
+                        # use the first match
+                        break
+
+        batch_dfr3_sets = self.batch_get_dfr3_set(matched_curve_ids)
+
+        # replace the curve id in dfr3_sets to the dfr3 curve
+        for inventory_id, curve_item in dfr3_sets.items():
+            if isinstance(curve_item, FragilityCurveSet) or isinstance(curve_item, RepairCurveSet) \
+                    or isinstance(curve_item, RestorationCurveSet):
                 pass
             elif isinstance(curve_item, str):
                 dfr3_sets[inventory_id] = batch_dfr3_sets[curve_item]

--- a/tests/data/pipe_restorationset.json
+++ b/tests/data/pipe_restorationset.json
@@ -1,0 +1,56 @@
+{
+    "description" : "Restoration function for pipeline restoration for class a,b,c",
+    "authors" : [ "HAZUS"
+    ],
+    "resultType" : "Restoration Time",
+    "hazardType" : "earthquake",
+    "inventoryType" : "water_pipeline",
+    "timeUnits" : "days",
+    "restorationCurves" : [
+        {
+            "description" : "Time taken to repair a pipeline",
+            "rules" : [
+                {
+                    "condition" : null,
+                    "expression" : "(break_rate*0.33 + leak_rate*0.66)*pipe_length/num_workers"
+                }
+            ],
+            "returnType" : {
+                "type" : "Restoration Time",
+                "unit" : "days",
+                "description" : "RT"
+            }
+        }
+    ],
+
+    "curveParameters" : [
+        {
+            "name" : "break_rate",
+            "unit" : "",
+            "description" : "Break rate for pipelines",
+            "fullName" : "break_rate",
+            "expression" : null
+        },
+        {
+            "name" : "leak_rate",
+            "unit" : "",
+            "description" : "Leak rate for pipelines",
+            "fullName" : "leak_rate",
+            "expression" : null
+        },
+        {
+            "name" : "pipe_length",
+            "unit" : "??",
+            "description" : "Length of pipelines",
+            "fullName" : "pipe_length",
+            "expression" : null
+        },
+        {
+            "name" : "num_workers",
+            "unit" : "",
+            "description" : "Number of workers working on the repairs",
+            "fullName" : "num_workers",
+            "expression" : "4"
+        }
+    ]
+}

--- a/tests/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
+++ b/tests/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
@@ -26,7 +26,7 @@ def run_with_base_class():
 
     pipeline_restoration.set_parameter("restoration_key", "Restoration ID Code")
     pipeline_restoration.set_parameter("num_available_workers", 4)
-    pipeline_restoration.set_parameter("num_cpu", 1)
+    pipeline_restoration.set_parameter("num_cpu", 4)
 
     # Run pipeline damage analysis
     result = pipeline_restoration.run_analysis()

--- a/tests/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
+++ b/tests/pyincore/analyses/pipelinerestoration/test_pipelinerestoration.py
@@ -22,7 +22,7 @@ def run_with_base_class():
     mapping_set = MappingSet(fragility_service.get_mapping("61f35f09903e515036cee106"))
     pipeline_restoration.set_input_dataset('dfr3_mapping_set', mapping_set)
 
-    pipeline_restoration.set_parameter("result_name","pipeline_restoration_times")
+    pipeline_restoration.set_parameter("result_name", "pipeline_restoration_times")
 
     pipeline_restoration.set_parameter("restoration_key", "Restoration ID Code")
     pipeline_restoration.set_parameter("num_available_workers", 4)

--- a/tests/pyincore/models/test_dfr3curve.py
+++ b/tests/pyincore/models/test_dfr3curve.py
@@ -136,3 +136,16 @@ def test_calculate_restoration_rates(restoration_set, args, expected):
         assert result["PF_0"] == expected
     else:
         assert False
+
+@pytest.mark.parametrize("restoration_set,args,expected", [
+    (get_restoration_set("pipe_restorationset.json"), {"break_rate": 0.2, "leak_rate": 0.4,
+                                                       "pipe_length": 80, "num_workers": 8}, 3.3000000000000003)
+])
+def test_calculate_pipeline_restoration_rates(restoration_set, args, expected):
+    result = restoration_set.calculate_restoration_rates(**args)
+    print(result)
+    if type(result["RT"]) == numpy.ndarray:
+        assert numpy.allclose(result["RT"], expected, rtol=1e-03, atol=1e-03)
+    else:
+        assert result["RT"] == expected
+


### PR DESCRIPTION
Closes #78 

This works but the repair times are very small for the input datasets being used, the reason being the break and leak rates are very small(all less than 1 day) in the pipeline damage output file (input of this analysis), and the diameter of the pipes being small (all have 2 inch diameter). I'm going to see if I can find other datasets/hazards that have higher damage and hence show larger repair times.

We should check:
1. if the smaller repair times in this case is ok and double check the expression being used. (should the repair rates be multiplied by 100 before calculating?)
2. are there other datasets (seaside?), that have more varied inputs than the shelby county one which has all pipes diameter set to 2 inches. If there is such dataset, I'll create another test
3. There is also a warning with this dataset, when it is loaded to a dataframe. It's probably not impacting anything, but worth checking `INFO - collection.py:crs() - Failed to auto identify EPSG: 7`