### PR TITLE
Rewrite the epf and wf restoration model #100

### DIFF
--- a/pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py
+++ b/pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py
@@ -98,14 +98,6 @@ class WaterFacilityRestoration(BaseAnalysis):
         pf_results = []
 
         for mapping in mapping_set.mappings:
-            # parse rules to get inventory class. e.g. treatment plan, tank, pump etc
-            if isinstance(mapping.rules, list):
-                inventory_class = RestorationService.extract_inventory_class_legacy(mapping.rules)
-            elif isinstance(mapping.rules, dict):
-                inventory_class = RestorationService.extract_inventory_class(mapping.rules)
-            else:
-                raise ValueError("Unsupported mapping rules!")
-
             # get restoration curves
             # if it's string:id; then need to fetch it from remote and cast to restorationcurveset object
             restoration_curve_set = mapping.entry[restoration_key]
@@ -116,7 +108,7 @@ class WaterFacilityRestoration(BaseAnalysis):
             time = np.arange(0, end_time + time_interval, time_interval)
             for t in time:
                 pf_results.append({
-                    "inventory_class": inventory_class,
+                    "restoration_id": restoration_curve_set.id,
                     "time": t,
                     **restoration_curve_set.calculate_restoration_rates(time=t)
                 })
@@ -129,7 +121,7 @@ class WaterFacilityRestoration(BaseAnalysis):
                 for key, value in t_res.items():
                     new_dict.update({"time_" + key: value})
                 time_results.append({
-                    "inventory_class": inventory_class,
+                    "restoration_id": restoration_curve_set.id,
                     "percentage_of_functionality": p,
                     **new_dict
                 })

--- a/pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py
+++ b/pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py
@@ -82,7 +82,7 @@ class WaterFacilityRestoration(BaseAnalysis):
             pf_results (list): Given Repair time, change of the percentage of functionality
         """
 
-        # Obtain the restoration id for each building
+        # Obtain the restoration id for each water facility
         inventory_restoration_map = []
         restoration_sets = self.restorationsvc.match_inventory(
             self.get_input_dataset("dfr3_mapping_set"), inventory_list, restoration_key)

--- a/tests/pyincore/analyses/electricpowerfacilityrestoration/test_electricpowerfacilityrestoration.py
+++ b/tests/pyincore/analyses/electricpowerfacilityrestoration/test_electricpowerfacilityrestoration.py
@@ -14,6 +14,7 @@ def run_with_base_class():
     epf_rest = ElectricPowerFacilityRestoration(client)
     restorationsvc = RestorationService(client)
     mapping_set = MappingSet(restorationsvc.get_mapping("61f302e6e3a03e465500b3eb"))  # new format of mapping
+    epf_rest.load_remote_input_dataset('epfs', '6189c103d5b02930aa3efc35')
     epf_rest.set_input_dataset('dfr3_mapping_set', mapping_set)
     epf_rest.set_parameter("result_name", "epf_restoration.csv")
     epf_rest.set_parameter("restoration_key", "Restoration ID Code")

--- a/tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py
+++ b/tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py
@@ -16,6 +16,7 @@ def run_with_base_class():
     # Load restoration mapping
     restorationsvc = RestorationService(client)
     mapping_set = MappingSet(restorationsvc.get_mapping("61f075ee903e515036cee0a5"))  # new format of mapping
+    wf_rest.load_remote_input_dataset("water_facilities", "5a284f2ac7d30d13bc081e52")  # water facility
     wf_rest.set_input_dataset('dfr3_mapping_set', mapping_set)
     wf_rest.set_parameter("result_name", "wf_restoration")
     wf_rest.set_parameter("restoration_key", "Restoration ID Code")


### PR DESCRIPTION
rewrite WF and EPF so now it produces 3 tables
1. guid -> restoration id
2. restoration id, time, PF_0, PF_1, ...
3. restoration id, PF, time_0, time_1, ...

here is an example:
[inventory_restoration_map_wf_restoration.csv](https://github.com/IN-CORE/pyincore/files/8112415/inventory_restoration_map_wf_restoration.csv)
[reptime_wf_restoration.csv](https://github.com/IN-CORE/pyincore/files/8112416/reptime_wf_restoration.csv)
[percentage_of_functionality_wf_restoration.csv](https://github.com/IN-CORE/pyincore/files/8112417/percentage_of_functionality_wf_restoration.csv)


*note* I also updated the mappings according to the Hazus table
![Table 3 24 Electric Power System Classification](https://user-images.githubusercontent.com/13950475/155034453-7982a6e8-4929-4d49-aee3-395afb1e7515.png)
![Table 3 20 Potable Water System Classification](https://user-images.githubusercontent.com/13950475/155034467-350fc530-c154-499e-b157-456affade5f6.png)

