### PR TITLE
53: remove mean damage data types for which we don't have damage ratios

### DIFF
--- a/pyincore/analyses/meandamage/meandamage.py
+++ b/pyincore/analyses/meandamage/meandamage.py
@@ -176,7 +176,7 @@ class MeanDamage(BaseAnalysis):
         """Calculates mean damage based on damage probabilities and damage ratios
 
         Args:
-            dmg (obj): dmg analysis output for a single building.
+            dmg (obj): dmg analysis output for a single entity in the built environment
             dmg_ratio_tbl (list): dmg ratio table.
             damage_interval_keys (list): damage interval keys
             is_bridge (bool): a boolean to indicate if the inventory type is bridge.

--- a/pyincore/analyses/meandamage/meandamage.py
+++ b/pyincore/analyses/meandamage/meandamage.py
@@ -57,18 +57,9 @@ class MeanDamage(BaseAnalysis):
                              'ergo:bridgeDamage',
                              'ergo:bridgeDamageVer2',
                              'ergo:bridgeDamageVer3',
-                             'ergo:waterFacilityDamageVer4',
-                             'ergo:waterFacilityDamageVer5',
-                             'ergo:waterFacilityDamageVer6',
                              'ergo:roadDamage',
                              'ergo:roadDamageVer2',
-                             'ergo:roadDamageVer3',
-                             'incore:epfDamage',
-                             'incore:epfDamageVer2',
-                             'incore:epfDamageVer3',
-                             'incore:pipelineDamage',
-                             'incore:pipelineDamageVer2',
-                             'incore:pipelineDamageVer3']
+                             'ergo:roadDamageVer3']
                 },
                 {
                     'id': 'dmg_ratios',
@@ -79,7 +70,7 @@ class MeanDamage(BaseAnalysis):
                              'ergo:buildingContentDamageRatios',
                              'ergo:buildingASDamageRatios',
                              'ergo:buildingDSDamageRatios',
-                             'ergo:roadDamageRatios'],
+                             'ergo:roadDamageRatios']
                 },
 
             ],

--- a/pyincore/analyses/meandamage/meandamage.py
+++ b/pyincore/analyses/meandamage/meandamage.py
@@ -173,10 +173,10 @@ class MeanDamage(BaseAnalysis):
         return result
 
     def mean_damage(self, dmg, dmg_ratio_tbl, damage_interval_keys, is_bridge):
-        """Calculates building damage results for a single building.
+        """Calculates mean damage based on damage probabilities and damage ratios
 
         Args:
-            dmg (obj): dmg analysis output for a single entry.
+            dmg (obj): dmg analysis output for a single building.
             dmg_ratio_tbl (list): dmg ratio table.
             damage_interval_keys (list): damage interval keys
             is_bridge (bool): a boolean to indicate if the inventory type is bridge.


### PR DESCRIPTION
This task shouldn't impact anything. 
Non-structural mean damage is probably broken because the damage ratio datasets related to AS/DS are still using slight, moderate etc. instead of DS_X convention - This task doesn't fix it. It will be fixed in #52