### PR TITLE
change setup.py for supporting legacy naming convention for package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Made pyincore build with legacy naming for pypi publish [#138](https://github.com/IN-CORE/pyincore/issues/138)
+
 ## [1.4.1] - 2022-04-22
 
 ### Fixed
@@ -14,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.4.0] - 2022-03-30
 
 ### Added
-- Add check to mean damage analysis to verify damage keys match inventory type and remove unsupported types [#53](https://github.com/IN-CORE/pyincore/issues/53)
+- Check to mean damage analysis to verify damage keys match inventory type and remove unsupported types [#53](https://github.com/IN-CORE/pyincore/issues/53)
 - Housing recovery model analysis [#99](https://github.com/IN-CORE/pyincore/issues/99)
 - Social vulnerability analysis [#106](https://github.com/IN-CORE/pyincore/issues/106)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ pkg_resources.extern.packaging.version.Version = pkg_resources.SetuptoolsLegacyV
 
 setup(
     name='pyincore',
-    version='1.4.1.rc.1',
+    version='1.4.1',
     packages=find_packages(where=".", exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,12 @@
 # and is available at https://www.mozilla.org/en-US/MPL/2.0/
 
 from setuptools import setup, find_packages
+import pkg_resources
+pkg_resources.extern.packaging.version.Version = pkg_resources.SetuptoolsLegacyVersion
 
 setup(
     name='pyincore',
-    version='1.4.1',
+    version='1.4.1.rc.1',
     packages=find_packages(where=".", exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
This is for supporting the package naming convention when building pyincore for publishing to pypi. 
The current one normalizes the name based on pep 440, for example, if the name is 
pyincore.1.4.1.rc.1, it will automatically normalize the name as pyincore.1.4.1rc1 for fitting to pep 440. 
The code added in this PR will allow the name still be pyincore.1.4.1.rc.1 when building the package using bdist_wheel, so the user can install the package like `pip install pyincore==1.4.1.rc.1` instead of `pip install pyincore==1.4.1rc1`