### PR TITLE
refactored tornado epn damage analysis to use network dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Made pyincore build with legacy naming for pypi publish [#138](https://github.com/IN-CORE/pyincore/issues/138)
 - Network dataset's sub category's dataType has been changed from networkType to dataType [#145](https://github.com/IN-CORE/pyincore/issues/145)
+- Tornado EPN damage analysis uses network dataset instead of link, node, graph datasets [#147](https://github.com/IN-CORE/pyincore/issues/147)
 
 ## [1.4.1] - 2022-04-22
 

--- a/pyincore/analyses/housingrecovery/housingrecovery.py
+++ b/pyincore/analyses/housingrecovery/housingrecovery.py
@@ -269,8 +269,8 @@ class HousingRecovery(BaseAnalysis):
         """
         hse_rec["tractid"] = hse_rec["tractid"].astype(str)
         # Add county and state to trac to match hse_rec tracid (Galveston - 723900 to 48167723900)
-        vac_status["tractid"] = vac_status["state"].astype(str) + vac_status["county"].astype(str) + \
-                                vac_status["tract"].astype(str)
+        vac_status["tractid"] = \
+            vac_status["state"].astype(str) + vac_status["county"].astype(str) + vac_status["tract"].astype(str)
 
         hse_rec_merged = pd.merge(hse_rec, vac_status, left_on="tractid", right_on="tractid", how='inner')
         return hse_rec_merged
@@ -336,12 +336,12 @@ class HousingRecovery(BaseAnalysis):
         else:
             dmg_loss = np.fromiter(hru.B_PHM_dmg_year.values(), dtype=float) * \
                        hse_rec["value_loss"].to_numpy()[:, np.newaxis]
-        d_owner = np.fromiter(hru.B_PHM_own_year.values(), dtype=float) * \
-                  hse_rec["d_ownerocc"].to_numpy()[:, np.newaxis]
-        mhhinck = np.fromiter(hru.B_PHM_inc_year.values(), dtype=float) * \
-                  hse_rec["mhhinck"].to_numpy()[:, np.newaxis]
-        pminrbg = np.fromiter(hru.B_PHM_min_year.values(), dtype=float) * \
-                  hse_rec["pminoritybg"].to_numpy()[:, np.newaxis]
+        d_owner = \
+            np.fromiter(hru.B_PHM_own_year.values(), dtype=float) * hse_rec["d_ownerocc"].to_numpy()[:, np.newaxis]
+        mhhinck = \
+            np.fromiter(hru.B_PHM_inc_year.values(), dtype=float) * hse_rec["mhhinck"].to_numpy()[:, np.newaxis]
+        pminrbg = \
+            np.fromiter(hru.B_PHM_min_year.values(), dtype=float) * hse_rec["pminoritybg"].to_numpy()[:, np.newaxis]
 
         return coef_fin + yrbuilt + sqmeter + d_owner + dmg_loss + mhhinck + pminrbg
 
@@ -376,10 +376,9 @@ class HousingRecovery(BaseAnalysis):
         else:
             dmg_loss = np.fromiter(hru.B_SVHM_dmg_year.values(), dtype=float) * \
                        hse_rec["value_loss"].to_numpy()[:, np.newaxis]
-        d_owner = np.fromiter(hru.B_SVHM_own_year.values(), dtype=float) * \
-                  hse_rec["d_ownerocc"].to_numpy()[:, np.newaxis]
-        mhhinck = np.fromiter(hru.B_SVHM_inc_year.values(), dtype=float) * \
-                  hse_rec["mhhinck"].to_numpy()[:, np.newaxis]
+        d_owner = \
+            np.fromiter(hru.B_SVHM_own_year.values(), dtype=float) * hse_rec["d_ownerocc"].to_numpy()[:, np.newaxis]
+        mhhinck = \
+            np.fromiter(hru.B_SVHM_inc_year.values(), dtype=float) * hse_rec["mhhinck"].to_numpy()[:, np.newaxis]
 
         return coef_fin + yrbuilt + sqmeter + dmg_loss + d_owner + mhhinck
-

--- a/pyincore/analyses/housingrecovery/housingrecoveryutil.py
+++ b/pyincore/analyses/housingrecovery/housingrecoveryutil.py
@@ -80,7 +80,7 @@ class HousingRecoveryUtil:
     B_SVHM_intercept = 11.125636
 
     # Year indicator dummy variables
-    B_SVHM_year =  {}
+    B_SVHM_year = {}
     B_SVHM_year[-1] = 0.000000  # year -1, tax assessment immediately before disaster
     B_SVHM_year[0] = 1.489008  # year  0, tax assessment immediately after disaster, damage year
     B_SVHM_year[1] = 1.858770  # year +1

--- a/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
+++ b/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
@@ -14,7 +14,7 @@ from pyincore.utils.analysisutil import AnalysisUtil
 from shapely.geometry import shape, LineString, MultiLineString
 
 from pyincore import BaseAnalysis, HazardService, FragilityService, DataService, FragilityCurveSet
-from pyincore import GeoUtil, NetworkUtil
+from pyincore import GeoUtil, NetworkUtil, NetworkDataset
 from pyincore.models.dfr3curve import DFR3Curve
 
 
@@ -88,8 +88,9 @@ class TornadoEpnDamage(BaseAnalysis):
         super(TornadoEpnDamage, self).__init__(incore_client)
 
     def run(self):
-        node_dataset = self.get_input_dataset("epn_node").get_inventory_reader()
-        link_dataset = self.get_input_dataset("epn_link").get_inventory_reader()
+        network_dataset = self.get_input_dataset("epn_network")
+        link_dataset = NetworkDataset._network_component_from_dataset(network_dataset, "link").get_inventory_reader()
+        node_dataset = NetworkDataset._network_component_from_dataset(network_dataset, "node").get_inventory_reader()
         tornado_id = self.get_parameter('tornado_id')
         tornado_metadata = self.hazardsvc.get_tornado_hazard_metadata(tornado_id)
         self.load_remote_input_dataset("tornado", tornado_metadata["datasetId"])
@@ -527,16 +528,10 @@ class TornadoEpnDamage(BaseAnalysis):
             ],
             'input_datasets': [
                 {
-                    'id': 'epn_node',
+                    'id': 'epn_network',
                     'required': True,
-                    'description': 'EPN Node',
-                    'type': ['incore:epnNodeVer1'],
-                },
-                {
-                    'id': 'epn_link',
-                    'required': True,
-                    'description': 'EPN Link',
-                    'type': ['incore:epnLinkeVer1'],
+                    'description': 'EPN Network Dataset',
+                    'type': ['incore:epnNetwork'],
                 },
                 {
                     'id': 'tornado',
@@ -548,13 +543,13 @@ class TornadoEpnDamage(BaseAnalysis):
             'output_datasets': [
                 {
                     'id': 'result',
-                    'parent_type': 'epn_node',
+                    'parent_type': 'epn_network',
                     'description': 'CSV file of damages for electric power network by tornado',
                     'type': 'incore:tornadoEPNDamageVer3'
                 },
                 {
                     'id': 'metadata',
-                    'parent_type': 'epn_node',
+                    'parent_type': 'epn_network',
                     'description': 'Json file with information about applied hazard value and fragility',
                     'type': 'incore:tornadoEPNDamageSupplement'
                 }

--- a/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
+++ b/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
@@ -88,9 +88,9 @@ class TornadoEpnDamage(BaseAnalysis):
         super(TornadoEpnDamage, self).__init__(incore_client)
 
     def run(self):
-        network_dataset = self.get_input_dataset("epn_network")
-        link_dataset = NetworkDataset._network_component_from_dataset(network_dataset, "link").get_inventory_reader()
-        node_dataset = NetworkDataset._network_component_from_dataset(network_dataset, "node").get_inventory_reader()
+        network_dataset = NetworkDataset.from_dataset(self.get_input_dataset("epn_network"))
+        link_dataset = network_dataset.links.get_inventory_reader()
+        node_dataset = network_dataset.nodes.get_inventory_reader()
         tornado_id = self.get_parameter('tornado_id')
         tornado_metadata = self.hazardsvc.get_tornado_hazard_metadata(tornado_id)
         self.load_remote_input_dataset("tornado", tornado_metadata["datasetId"])

--- a/pyincore/models/networkdataset.py
+++ b/pyincore/models/networkdataset.py
@@ -55,6 +55,20 @@ class NetworkDataset:
         return cls(dataset)
 
     @classmethod
+    def from_dataset(cls, dataset: Dataset):
+        """Turn Dataset into network component
+
+        Args:
+            dataset (obj): Dataset Object.
+
+        Returns:
+            obj: network dataset
+
+        """
+
+        return cls(dataset)
+
+    @classmethod
     def from_json_str(cls, json_str, data_service: DataService = None, folder_path=None):
         """Get Dataset from json string.
 

--- a/tests/pyincore/analyses/housingrecovery/test_housingrecovery.py
+++ b/tests/pyincore/analyses/housingrecovery/test_housingrecovery.py
@@ -24,7 +24,7 @@ def run_with_base_class(chained):
         bldg_inv_id = "602eba8bb1db9c28aef01358"
 
         # Hurricane building mapping (with equation)
-        mapping_id = "602c381a1d85547cdc9f0675" # dev & prod
+        mapping_id = "602c381a1d85547cdc9f0675"  # dev & prod
         fragility_service = FragilityService(client)
         mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
 
@@ -135,7 +135,7 @@ def run_with_base_class(chained):
         census_bg_id = "62193b7ca42a3e546ae2d9f2"
 
         # Census appraisal file; id of external Census json
-        census_appr_id = "6241fbd153302c512d685181" # dev
+        census_appr_id = "6241fbd153302c512d685181"  # dev
         result_name = "Galveston_building_values_chained"
 
         housing_rec = HousingRecovery(client)

--- a/tests/pyincore/analyses/tornadoepndamage/test_tornadoepndamage.py
+++ b/tests/pyincore/analyses/tornadoepndamage/test_tornadoepndamage.py
@@ -4,17 +4,15 @@ from pyincore import IncoreClient
 import pyincore.globals as pyglobals
 
 
-def run_with_base_class():
+def test_run_with_base_class():
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
 
     ted = TornadoEpnDamage(client)
 
-    epn_node_id = '5b1fdb50b1cf3e336d7cecb1'
-    epn_link_id = '5b1fdc2db1cf3e336d7cecc9'
+    epn_network_id = "62719fc857f1d94b047447e6"
     tornado_id = '5df913b83494fe000861a743'
 
-    ted.load_remote_input_dataset("epn_node", epn_node_id)
-    ted.load_remote_input_dataset("epn_link", epn_link_id)
+    ted.load_remote_input_dataset("epn_network", epn_network_id)
 
     result_name = "tornado_dmg_result"
     ted.set_parameter("result_name", result_name)
@@ -25,4 +23,4 @@ def run_with_base_class():
 
 
 if __name__ == '__main__':
-    run_with_base_class()
+    test_run_with_base_class()

--- a/tests/pyincore/analyses/tornadoepndamage/test_tornadoepndamage.py
+++ b/tests/pyincore/analyses/tornadoepndamage/test_tornadoepndamage.py
@@ -4,7 +4,7 @@ from pyincore import IncoreClient
 import pyincore.globals as pyglobals
 
 
-def test_run_with_base_class():
+def run_with_base_class():
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
 
     ted = TornadoEpnDamage(client)
@@ -23,4 +23,4 @@ def test_run_with_base_class():
 
 
 if __name__ == '__main__':
-    test_run_with_base_class()
+    run_with_base_class()

--- a/tests/pyincore/test_analysis.py
+++ b/tests/pyincore/test_analysis.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2019 University of Illinois and others. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License v2.0 which accompanies this distribution,
+# and is available at https://www.mozilla.org/en-US/MPL/2.0/
+
+import pytest
+
+from pyincore import globals as pyglobals
+from pyincore.analyses.tornadoepndamage.tornadoepndamage import \
+    TornadoEpnDamage
+from pyincore import IncoreClient
+
+
+@pytest.fixture
+def datasvc():
+    return pytest.datasvc
+
+
+def test_tornado_epn_damage_analysis(datasvc):
+    client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
+
+    ted = TornadoEpnDamage(client)
+
+    epn_network_id = "62719fc857f1d94b047447e6"
+    tornado_id = '5df913b83494fe000861a743'
+
+    ted.load_remote_input_dataset("epn_network", epn_network_id)
+
+    result_name = "tornado_dmg_result"
+    ted.set_parameter("result_name", result_name)
+    ted.set_parameter('tornado_id', tornado_id)
+    ted.set_parameter('seed', 1001)
+
+    ted.run_analysis()


### PR DESCRIPTION
Tornado EPN damage has been refactored to use network dataset. I also added pytest for github action called test_analysis.py and this contains the pytest of tornado epn damage. Also, there are format fix of other analysis as well but they are simply the format fixes so the contents are the same. You can test this PR using following code
```
    client = IncoreClient("https://incore-dev.ncsa.illinois.edu")

    ted = TornadoEpnDamage(client)

    epn_network_id = "62719fc857f1d94b047447e6"
    tornado_id = '5df913b83494fe000861a743'

    ted.load_remote_input_dataset("epn_network", epn_network_id)

    result_name = "tornado_dmg_result"
    ted.set_parameter("result_name", result_name)
    ted.set_parameter('tornado_id', tornado_id)
    ted.set_parameter('seed', 1001)

    ted.run_analysis()
```