### PR TITLE
WIP 168 replace social vulnerability computation with dataset coming from sv analysis

### DIFF
--- a/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
+++ b/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
@@ -150,7 +150,6 @@ class HousingRecoverySequential(BaseAnalysis):
         # Obtain a social vulnerability score stochastically per household
         # We use them later to construct the final output dataset
         sv_scores = self.compute_social_vulnerability_values(sv_result, households_df)
-        # sv_scores = self.compute_social_vulnerability_values(households_df, num_households, rng)
 
         # We store Markov states as a list of numpy arrays for convenience and add each one by one
         markov_stages = np.zeros((stages, num_households))

--- a/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
+++ b/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
@@ -132,6 +132,8 @@ class HousingRecoverySequential(BaseAnalysis):
         seed = self.get_parameter('seed')
         rng = np.random.RandomState(seed)
         sv_result = self.get_input_dataset("sv_result").get_dataframe_from_csv(low_memory=False)
+        # turn fips code to string for ease of matching
+        sv_result["FIPS"] = sv_result["FIPS"].astype(str)
 
         # Compute the social vulnerability zone using known factors
         households_df = self.compute_social_vulnerability_zones(sv_result, households_df)
@@ -290,6 +292,33 @@ class HousingRecoverySequential(BaseAnalysis):
 
         return households_df[households_df['Zone'] != 'missing']
 
+    # def compute_social_vulnerability_values(self, households_df, num_households, rng):
+    #     """
+    #     Compute the social vulnerability score of a household depending on its zone
+    #     Args:
+    #         households_df (pd.DataFrame): Information about household zones.
+    #         num_households (int): Number of households.
+    #         rng (np.RandomState): Random state to draw pseudo-random numbers from.
+    #     Returns:
+    #         pd.Series: social vulnerability scores.
+    #     """
+    #     # Social vulnerability zone generator: this generalizes the code in the first version
+    #     sv_scores = np.zeros(num_households)
+    #     zones = households_df['Zone'].to_numpy()
+    # 
+    #     for household in range(0, num_households):
+    #         spin = rng.rand()
+    #         zone = zones[household]
+    # 
+    #         if spin < self.__sv_generator[zone]['threshold']:
+    #             sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['below_lower'],
+    #                                                      self.__sv_generator[zone]['below_upper']), 3)
+    #         else:
+    #             sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['above_lower'],
+    #                                                      self.__sv_generator[zone]['above_upper']), 3)
+    # 
+    #     return sv_scores
+
     @staticmethod
     def compute_social_vulnerability_values(sv_result, households_df):
         """
@@ -315,13 +344,7 @@ class HousingRecoverySequential(BaseAnalysis):
 
         tmp = households_df.merge(sv_result, left_on="blockfips", right_on="FIPS")
         sv_scores = tmp["SVS"].T.to_numpy()
-        # num_households = households_df.shape[1]
-        #
-        # sv_scores = np.zeros(num_households)
-        #
-        # for household in range(0, num_households):
-        #     sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['below_lower'],
-        #                                              self.__sv_generator[zone]['below_upper']), 3)
+
         return sv_scores
 
     @staticmethod

--- a/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
+++ b/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
@@ -149,7 +149,8 @@ class HousingRecoverySequential(BaseAnalysis):
 
         # Obtain a social vulnerability score stochastically per household
         # We use them later to construct the final output dataset
-        sv_scores = self.compute_social_vulnerability_values(sv_result, households_df)
+        # sv_scores = self.compute_social_vulnerability_values(sv_result, households_df)
+        sv_scores = self.compute_social_vulnerability_values(households_df, num_households, rng)
 
         # We store Markov states as a list of numpy arrays for convenience and add each one by one
         markov_stages = np.zeros((stages, num_households))
@@ -292,60 +293,60 @@ class HousingRecoverySequential(BaseAnalysis):
 
         return households_df[households_df['Zone'] != 'missing']
 
-    # def compute_social_vulnerability_values(self, households_df, num_households, rng):
-    #     """
-    #     Compute the social vulnerability score of a household depending on its zone
-    #     Args:
-    #         households_df (pd.DataFrame): Information about household zones.
-    #         num_households (int): Number of households.
-    #         rng (np.RandomState): Random state to draw pseudo-random numbers from.
-    #     Returns:
-    #         pd.Series: social vulnerability scores.
-    #     """
-    #     # Social vulnerability zone generator: this generalizes the code in the first version
-    #     sv_scores = np.zeros(num_households)
-    #     zones = households_df['Zone'].to_numpy()
-    # 
-    #     for household in range(0, num_households):
-    #         spin = rng.rand()
-    #         zone = zones[household]
-    # 
-    #         if spin < self.__sv_generator[zone]['threshold']:
-    #             sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['below_lower'],
-    #                                                      self.__sv_generator[zone]['below_upper']), 3)
-    #         else:
-    #             sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['above_lower'],
-    #                                                      self.__sv_generator[zone]['above_upper']), 3)
-    # 
-    #     return sv_scores
-
-    @staticmethod
-    def compute_social_vulnerability_values(sv_result, households_df):
+    def compute_social_vulnerability_values(self, households_df, num_households, rng):
         """
         Compute the social vulnerability score of a household depending on its zone
-
         Args:
-            sv_result (pd.DataFrame): Social Vulnerability Score calculated from social vulnerability analysis
             households_df (pd.DataFrame): Information about household zones.
-
+            num_households (int): Number of households.
+            rng (np.RandomState): Random state to draw pseudo-random numbers from.
         Returns:
             pd.Series: social vulnerability scores.
-
         """
-        # merge sv result based on FIPS and blockfips into households df and construct a sv_scores dataframe
-        sv_result["FIPS"] = sv_result["FIPS"].astype(str)
+        # Social vulnerability zone generator: this generalizes the code in the first version
+        sv_scores = np.zeros(num_households)
+        zones = households_df['Zone'].to_numpy()
 
-        # if FIPS has 11 digits (Tract level)
-        if len(sv_result["FIPS"].iloc[0]) == 11:
-            households_df['blockfips'] = households_df['blockid'].apply(lambda x: str(x)[:11]).astype(str)
-        # if FIPS has 12 digits (Block Group level)
-        elif len(sv_result["FIPS"].iloc[0]) == 12:
-            households_df['blockfips'] = households_df['blockid'].apply(lambda x: str(x)[:12]).astype(str)
+        for household in range(0, num_households):
+            spin = rng.rand()
+            zone = zones[household]
 
-        tmp = households_df.merge(sv_result, left_on="blockfips", right_on="FIPS")
-        sv_scores = tmp["SVS"].T.to_numpy()
+            if spin < self.__sv_generator[zone]['threshold']:
+                sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['below_lower'],
+                                                         self.__sv_generator[zone]['below_upper']), 3)
+            else:
+                sv_scores[household] = round(rng.uniform(self.__sv_generator[zone]['above_lower'],
+                                                         self.__sv_generator[zone]['above_upper']), 3)
 
         return sv_scores
+
+    # @staticmethod
+    # def compute_social_vulnerability_values(sv_result, households_df):
+    #     """
+    #     Compute the social vulnerability score of a household depending on its zone
+    #
+    #     Args:
+    #         sv_result (pd.DataFrame): Social Vulnerability Score calculated from social vulnerability analysis
+    #         households_df (pd.DataFrame): Information about household zones.
+    #
+    #     Returns:
+    #         pd.Series: social vulnerability scores.
+    #
+    #     """
+    #     # merge sv result based on FIPS and blockfips into households df and construct a sv_scores dataframe
+    #     sv_result["FIPS"] = sv_result["FIPS"].astype(str)
+    #
+    #     # if FIPS has 11 digits (Tract level)
+    #     if len(sv_result["FIPS"].iloc[0]) == 11:
+    #         households_df['blockfips'] = households_df['blockid'].apply(lambda x: str(x)[:11]).astype(str)
+    #     # if FIPS has 12 digits (Block Group level)
+    #     elif len(sv_result["FIPS"].iloc[0]) == 12:
+    #         households_df['blockfips'] = households_df['blockid'].apply(lambda x: str(x)[:12]).astype(str)
+    #
+    #     tmp = households_df.merge(sv_result, left_on="blockfips", right_on="FIPS")
+    #     sv_scores = tmp["SVS"].T.to_numpy()
+    #
+    #     return sv_scores
 
     @staticmethod
     def compute_regressions(markov_stages, household, lower, upper):

--- a/tests/pyincore/analyses/housingrecoveryserial/test_housingrecoverysequential.py
+++ b/tests/pyincore/analyses/housingrecoveryserial/test_housingrecoverysequential.py
@@ -13,6 +13,7 @@ def run_with_base_class():
     population_dislocation = "60f098f502897f12fcda19ec"  # dev Galveston testbed
     transition_probability_matrix = "60ef513802897f12fcd9765c"
     initial_probability_vector = "60ef532e02897f12fcd9ac63"
+    sv_result = "62c5be23861e370172c5e412"
 
     seed = 1234
     t_delta = 1.0
@@ -29,6 +30,7 @@ def run_with_base_class():
     housing_recovery.load_remote_input_dataset("population_dislocation_block", population_dislocation)
     housing_recovery.load_remote_input_dataset('tpm', transition_probability_matrix)
     housing_recovery.load_remote_input_dataset('initial_stage_probabilities', initial_probability_vector)
+    housing_recovery.load_remote_input_dataset('sv_result', sv_result)
 
     housing_recovery.run()
 


### PR DESCRIPTION
Everything works except line 
```
 mv_index = np.where(tpm[:, 0] == sv_scores[household])[0][0]
```

Originally sv_scores are random values between lower and uppper bound (< 1.0) and tpm is also in that range; 
now the calculated sv_scores some times are > 1 which breaks the code.

Currently in discussion with Amin about this issue. 