### PR TITLE
Closes #169 - added discretized restoration output to epf

### DIFF
--- a/pyincore/analyses/epfrestoration/epfrestoration.py
+++ b/pyincore/analyses/epfrestoration/epfrestoration.py
@@ -9,7 +9,7 @@ Electric Power Facility Restoration
 
 import numpy as np
 
-from pyincore import BaseAnalysis, RestorationService
+from pyincore import BaseAnalysis, RestorationService, AnalysisUtil
 from pyincore.models.restorationcurveset import RestorationCurveSet
 
 
@@ -47,28 +47,38 @@ class EpfRestoration(BaseAnalysis):
         if pf_interval is None:
             pf_interval = 0.1
 
-        (inventory_restoration_map, pf_results, time_results) = self.electricpowerfacility_restoration(
-            inventory_list, mapping_set, restoration_key, end_time, time_interval, pf_interval)
+        restoration_table_dataset = self.get_input_dataset("restoration_table").get_csv_reader()
+        restoration_table = AnalysisUtil.get_csv_table_rows(restoration_table_dataset, ignore_first_row=False)
+
+        damage = self.get_input_dataset("damage").get_csv_reader()
+        damage_result = AnalysisUtil.get_csv_table_rows(damage, ignore_first_row=False)
+
+        (inventory_restoration_map, pf_results, time_results, func_results) = self.electricpowerfacility_restoration(
+            inventory_list, damage_result, mapping_set, restoration_key, end_time, time_interval, pf_interval, restoration_table)
 
         self.set_result_csv_data("inventory_restoration_map", inventory_restoration_map,
                                  name="inventory_restoration_map_" + self.get_parameter("result_name"))
         self.set_result_csv_data("pf_results", time_results, name="percentage_of_functionality_" +
                                                                   self.get_parameter("result_name"))
         self.set_result_csv_data("time_results", pf_results, name="reptime_" + self.get_parameter("result_name"))
+        self.set_result_csv_data("func_results", func_results,
+                                 name=self.get_parameter("result_name") + "_discretized_restoration")
 
         return True
 
-    def electricpowerfacility_restoration(self, inventory_list, mapping_set, restoration_key, end_time, time_interval,
-                                          pf_interval):
+    def electricpowerfacility_restoration(self, inventory_list, damage_result, mapping_set, restoration_key, end_time,
+                                          time_interval, pf_interval, restoration_table):
         """Gets applicable restoration curve set and calculates restoration time and functionality
 
         Args:
             inventory_list (list): Multiple EPF facilities from input inventory set.
+            damage_result: EPF damage
             mapping_set (class): Restoration Mapping Set
             restoration_key (str): Restoration Key to determine which curve to use. E.g. Restoration ID Code
             end_time (float): User specified end repair time
             time_interval (float): Increment interval of repair time. Default to 1 (1 day)
             pf_interval (float): Increment interval of percentage of functionality. Default 0.1 (10%)
+            restoration_table (list): Discretized restoration by classifcation
 
         Returns:
             time_results (list): Given Percentage of functionality, the change of repair time
@@ -77,6 +87,9 @@ class EpfRestoration(BaseAnalysis):
         """
         # Obtain the restoration id for each electric facilities
         inventory_restoration_map = []
+
+        # Obtain classification for each electric facility, used to lookup discretized functionality
+        inventory_class_map = {}
         restoration_sets = self.restorationsvc.match_inventory(
             self.get_input_dataset("dfr3_mapping_set"), inventory_list, restoration_key)
         for inventory in inventory_list:
@@ -84,8 +97,15 @@ class EpfRestoration(BaseAnalysis):
                 restoration_set_id = restoration_sets[inventory["id"]].id
             else:
                 restoration_set_id = None
+
+            if "utilfcltyc" in inventory["properties"]:
+                classification = inventory["properties"]["utilfcltyc"]
+            else:
+                classification = None
+
             inventory_restoration_map.append({"guid": inventory['properties']['guid'],
                                               "restoration_id": restoration_set_id})
+            inventory_class_map[inventory['properties']['guid']] = classification
 
         time_results = []
         pf_results = []
@@ -118,8 +138,30 @@ class EpfRestoration(BaseAnalysis):
                     "percentage_of_functionality": p,
                     **new_dict
                 })
+        restoration_class_dict = AnalysisUtil.get_discretized_restoration(restoration_table)
 
-        return inventory_restoration_map, pf_results, time_results
+        # Compute discretized restoration
+        func_result = []
+        for dmg in damage_result:
+            guid = dmg['guid']
+            classification = inventory_class_map[guid]
+            if classification in restoration_class_dict:
+                rest_dict = restoration_class_dict[classification]
+
+                ds_0, ds_1, ds_2, ds_3, ds_4 = dmg['DS_0'], dmg['DS_1'], dmg['DS_2'], dmg['DS_3'], dmg['DS_4']
+                result_dict = {}
+                for key in rest_dict:
+                    c0, c1, c2, c3, c4 = rest_dict[key][0], rest_dict[key][1], rest_dict[key][2], rest_dict[key][3], \
+                                         rest_dict[key][4]
+                    # Only compute if we have damage
+                    if ds_0:
+                        functionality = (c0 * float(ds_0) + c1 * float(ds_1) + c2 * float(ds_2) + c3 * float(ds_3) +
+                                         c4 * float(ds_4)) / 100.0
+                        result_dict.update({str(key): functionality})
+
+                func_result.append({"guid": guid, **result_dict})
+
+        return inventory_restoration_map, pf_results, time_results, func_result
 
     def get_spec(self):
         return {
@@ -169,7 +211,27 @@ class EpfRestoration(BaseAnalysis):
                     'required': True,
                     'description': 'DFR3 Mapping Set Object',
                     'type': ['incore:dfr3MappingSet'],
+                },
+                {
+
+                    'id': 'restoration_table',
+                    'required': True,
+                    'description': 'CSV of discretized restoration values',
+                    'type': ['incore:epfDiscretizedRestoration'],
+                },
+                {
+
+                    'id': 'damage',
+                    'required': True,
+                    'description': 'damage result that has damage intervals in it',
+                    'type': [
+                             'incore:epfDamage',
+                             'incore:epfDamageVer2',
+                             'incore:epfDamageVer3']
                 }
+
+
+
             ],
             'output_datasets': [
                 {
@@ -189,9 +251,17 @@ class EpfRestoration(BaseAnalysis):
                 {
                     'id': 'time_results',
                     'parent_type': '',
-                    'description': 'A csv file recording repair time at certain funcionality recovery for each class '
+                    'description': 'A csv file recording repair time at certain functionality recovery for each class '
                                    'and limit state.',
                     'type': 'incore:epfRestorationTime'
                 },
+                {
+
+                    'id': 'func_results',
+                    'parent_type': '',
+                    'description': 'A csv file recording discretized functionality over time',
+                    'type': 'incore:epfDiscretizedRestorationFunc'
+                }
+
             ]
         }

--- a/pyincore/utils/analysisutil.py
+++ b/pyincore/utils/analysisutil.py
@@ -596,3 +596,33 @@ class AnalysisUtil:
 
         """
         return any("-9999" in str(val) for val in hazard_vals)
+
+    @staticmethod
+    def get_discretized_restoration(restoration_table):
+        """Converts discretized restoration times into a dictionary
+
+        :param restoration_table:
+        :return: For each different classification, this returns discretized restoration in the form of
+            rest_dict = {day1: [100, 50, 9, 4, 3],
+                         day3: [100, 100, 50, 13, 4],
+                         day7: [100, 100, 100, 50, 7],
+                        day30: [100, 100, 100, 100, 50],
+                        day90: [100, 100, 100, 100, 100]}
+        """
+
+        restoration_map = {}
+        for restoration_row in restoration_table:
+            classification = restoration_row['Classification']
+            if classification in restoration_map:
+                class_restoration = restoration_map[classification]
+            else:
+                class_restoration = {"day1": [], "day3": [], "day7": [], "day30": [], "day90": []}
+                restoration_map[classification] = class_restoration
+
+            class_restoration["day1"].append(float(restoration_row["day1"]))
+            class_restoration["day3"].append(float(restoration_row["day3"]))
+            class_restoration["day7"].append(float(restoration_row["day7"]))
+            class_restoration["day30"].append(float(restoration_row["day30"]))
+            class_restoration["day90"].append(float(restoration_row["day90"]))
+
+        return restoration_map

--- a/pyincore/utils/analysisutil.py
+++ b/pyincore/utils/analysisutil.py
@@ -601,13 +601,11 @@ class AnalysisUtil:
     def get_discretized_restoration(restoration_table):
         """Converts discretized restoration times into a dictionary
 
-        :param restoration_table:
-        :return: For each different classification, this returns discretized restoration in the form of
-            rest_dict = {day1: [100, 50, 9, 4, 3],
-                         day3: [100, 100, 50, 13, 4],
-                         day7: [100, 100, 100, 50, 7],
-                        day30: [100, 100, 100, 100, 50],
-                        day90: [100, 100, 100, 100, 100]}
+        Args:
+            restoration_table(list):
+        Returns:
+            dict: Grouped discretized restoration by inventory class { 'EPPL': {day1: [100, 50, 9, 4, 3], day3: [100,
+            100, 50, 13, 4], etc }
         """
 
         restoration_map = {}

--- a/tests/pyincore/analyses/epfrestoration/test_epfrestoration.py
+++ b/tests/pyincore/analyses/epfrestoration/test_epfrestoration.py
@@ -3,19 +3,55 @@
 # and is available at https://www.mozilla.org/en-US/MPL/2.0/
 
 
-from pyincore import IncoreClient, MappingSet, RestorationService
+from pyincore import IncoreClient, MappingSet, RestorationService, FragilityService
 from pyincore.analyses.epfrestoration import EpfRestoration, EpfRestorationUtil
+from pyincore.analyses.epfdamage import EpfDamage
+
 import pyincore.globals as pyglobals
 
 
 def run_with_base_class():
+
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
+    
+    # Memphis EPF Damage with Earthquake
+    hazard_type_eq = "earthquake"
+    hazard_id_eq = "5b902cb273c3371e1236b36b"
+    epf_dataset_id = "6189c103d5b02930aa3efc35"
+    mapping_id = "61980cf5e32da63f4b9d86f5"  # PGA and PGD
+
+    use_liquefaction = True
+    use_hazard_uncertainty = False
+    liquefaction_geology_dataset_id = "5a284f53c7d30d13bc08249c"
+
+    # Run epf damage
+    epf_dmg_eq_memphis = EpfDamage(client)
+    epf_dmg_eq_memphis.load_remote_input_dataset("epfs", epf_dataset_id)
+
+    # Load fragility mapping
+    fragility_service = FragilityService(client)
+    mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
+    epf_dmg_eq_memphis.set_input_dataset('dfr3_mapping_set', mapping_set)
+
+    epf_dmg_eq_memphis.set_parameter("result_name", "memphis_eq_epf_dmg_result")
+    epf_dmg_eq_memphis.set_parameter("hazard_type", hazard_type_eq)
+    epf_dmg_eq_memphis.set_parameter("hazard_id", hazard_id_eq)
+    epf_dmg_eq_memphis.set_parameter("use_liquefaction", use_liquefaction)
+    epf_dmg_eq_memphis.set_parameter("use_hazard_uncertainty", use_hazard_uncertainty)
+    epf_dmg_eq_memphis.set_parameter("liquefaction_geology_dataset_id", liquefaction_geology_dataset_id)
+    epf_dmg_eq_memphis.set_parameter("num_cpu", 1)
+
+    # Run Analysis
+    epf_dmg_eq_memphis.run_analysis()
+    
     epf_rest = EpfRestoration(client)
     restorationsvc = RestorationService(client)
     mapping_set = MappingSet(restorationsvc.get_mapping("61f302e6e3a03e465500b3eb"))  # new format of mapping
-    epf_rest.load_remote_input_dataset('epfs', '6189c103d5b02930aa3efc35')
-    epf_rest.set_input_dataset('dfr3_mapping_set', mapping_set)
-    epf_rest.set_parameter("result_name", "epf_restoration.csv")
+    epf_rest.load_remote_input_dataset("epfs", "6189c103d5b02930aa3efc35")
+    epf_rest.set_input_dataset("dfr3_mapping_set", mapping_set)
+    epf_rest.set_input_dataset('damage', epf_dmg_eq_memphis.get_output_dataset("result"))
+    epf_rest.load_remote_input_dataset("restoration_table", "62c886ae861e370172c71194")
+    epf_rest.set_parameter("result_name", "memphis-epf")
     epf_rest.set_parameter("restoration_key", "Restoration ID Code")
     epf_rest.set_parameter("end_time", 100.0)
     epf_rest.set_parameter("time_interval", 1.0)


### PR DESCRIPTION
As discussed in the last dev meeting, I updated EpfRestoration to output discretized restoration. This required two new inputs:

1) EPF Damage to provide the damage probabilities
2) A new input dataset - incore:epfDiscretizedRestoration - from Hazus table 8-28 (ingested as 62c886ae861e370172c71194)

The unit test is updated to chain epf damage and use the new input referenced above.