### PR TITLE
Closes #170 - added discretized restoration output to water facility restoration

### DIFF
--- a/tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py
+++ b/tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py
@@ -3,7 +3,8 @@
 # and is available at https://www.mozilla.org/en-US/MPL/2.0/
 
 
-from pyincore import IncoreClient, MappingSet, RestorationService
+from pyincore import IncoreClient, MappingSet, RestorationService, FragilityService
+from pyincore.analyses.waterfacilitydamage import WaterFacilityDamage
 from pyincore.analyses.waterfacilityrestoration import WaterFacilityRestoration
 from pyincore.analyses.waterfacilityrestoration import WaterFacilityRestorationUtil
 import pyincore.globals as pyglobals
@@ -11,14 +12,50 @@ import pyincore.globals as pyglobals
 
 def run_with_base_class():
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
+
+    hazard_type = "earthquake"
+    hazard_id = "5b902cb273c3371e1236b36b"
+    facility_datasetid = "5a284f2ac7d30d13bc081e52"
+
+    mapping_id = "5b47c383337d4a387669d592"
+
+    liq_geology_dataset_id = "5a284f53c7d30d13bc08249c"
+
+    uncertainty = False
+    liquefaction = True
+    liq_fragility_key = "pgd"
+
+    wf_dmg = WaterFacilityDamage(client)
+    wf_dmg.load_remote_input_dataset("water_facilities", facility_datasetid)
+
+    # Load fragility mapping
+    fragility_service = FragilityService(client)
+    mapping_set = MappingSet(fragility_service.get_mapping(mapping_id))
+    wf_dmg.set_input_dataset('dfr3_mapping_set', mapping_set)
+
+    result_name = "wf-dmg-results.csv"
+    wf_dmg.set_parameter("result_name", result_name)
+    wf_dmg.set_parameter("hazard_type", hazard_type)
+    wf_dmg.set_parameter("hazard_id", hazard_id)
+    wf_dmg.set_parameter("fragility_key", "pga")
+    wf_dmg.set_parameter("use_liquefaction", liquefaction)
+    wf_dmg.set_parameter("liquefaction_geology_dataset_id", liq_geology_dataset_id)
+    wf_dmg.set_parameter("liquefaction_fragility_key", liq_fragility_key)
+    wf_dmg.set_parameter("use_hazard_uncertainty", uncertainty)
+    wf_dmg.set_parameter("num_cpu", 4)
+
+    wf_dmg.run_analysis()
+
     wf_rest = WaterFacilityRestoration(client)
 
     # Load restoration mapping
     restorationsvc = RestorationService(client)
     mapping_set = MappingSet(restorationsvc.get_mapping("61f075ee903e515036cee0a5"))  # new format of mapping
     wf_rest.load_remote_input_dataset("water_facilities", "5a284f2ac7d30d13bc081e52")  # water facility
+    wf_rest.set_input_dataset("damage", wf_dmg.get_output_dataset("result"))
     wf_rest.set_input_dataset('dfr3_mapping_set', mapping_set)
-    wf_rest.set_parameter("result_name", "wf_restoration")
+    wf_rest.load_remote_input_dataset("restoration_table", "62cc7e62861e370172c7e2f1")
+    wf_rest.set_parameter("result_name", "shelby-water-facility")
     wf_rest.set_parameter("restoration_key", "Restoration ID Code")
     wf_rest.set_parameter("end_time", 100.0)
     wf_rest.set_parameter("time_interval", 1.0)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -61,7 +61,11 @@ paths = [
     os.path.join(PYINCORE_ROOT_FOLDER, 'tests/pyincore/utils/test_popdisloutputprocess.py'),
     os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/housingrecovery/housingrecovery.py'),
     os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/housingrecovery/housingrecoveryutil.py'),
-    os.path.join(PYINCORE_ROOT_FOLDER, 'tests/pyincore/analyses/housingrecovery/test_housingrecovery.py')
+    os.path.join(PYINCORE_ROOT_FOLDER, 'tests/pyincore/analyses/housingrecovery/test_housingrecovery.py'),
+    os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py'),
+    os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/waterfacilityrestoration/waterfacilityrestorationutil.py'),
+    os.path.join(PYINCORE_ROOT_FOLDER,
+                 'tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py')
 ]
 
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -65,7 +65,7 @@ paths = [
     os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/waterfacilityrestoration/waterfacilityrestoration.py'),
     os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/waterfacilityrestoration/waterfacilityrestorationutil.py'),
     os.path.join(PYINCORE_ROOT_FOLDER,
-                 'tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py')
+                 'tests/pyincore/analyses/waterfacilityrestoration/test_waterfacilityrestoration.py'),
     os.path.join(PYINCORE_ROOT_FOLDER, 'pyincore/analyses/socialvulnerability/socialvulnerability.py'),
     os.path.join(PYINCORE_ROOT_FOLDER, 'tests/pyincore/analyses/socialvulnerability/test_socialvulnerability.py')
 ]


### PR DESCRIPTION
This follows the same logic as electric power facility restoration. Although the hazus table layout is the same, I created a new type for the discretized restoration. It could be argued that we should use the same type and ingest the tables using the same data type. EPF came from Table 8-28, the water facility came from Table 8-2. There are two new inputs for Water facility restoration:

1. Water facility damage to provide the damage probabilities
2. A new input dataset: incore:waterFacilityDiscretizedRestoration from Table 8-2 (ingested as 62cc7e62861e370172c7e2f1)

The unit test is updated to chain water facility damage and use the new input referenced above.