### PR TITLE
updated buildingeconloss to handle case with no occupancy_multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rewrote clustering utility function to use flexible archetype column [#247](https://github.com/IN-CORE/pyincore/issues/247)
 - Made documentation containter to use requirements instead of environemt [#257](https://github.com/IN-CORE/pyincore/issues/257)
 
+### Fixed
+- Duplicate input spec for housing recovery sequential model [#263](https://github.com/IN-CORE/pyincore/issues/263)
+
 ## [1.8.0] - 2022-11-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Rewrote clustering utility function to use flexible archetype column [#247](https://github.com/IN-CORE/pyincore/issues/247)
 - Made documentation containter to use requirements instead of environemt [#257](https://github.com/IN-CORE/pyincore/issues/257)
+- Parallelized the HHRS analysis [#268](https://github.com/IN-CORE/pyincore/issues/268)
 
 ### Fixed
 - Duplicate input spec for housing recovery sequential model [#263](https://github.com/IN-CORE/pyincore/issues/263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Duplicate input spec for housing recovery sequential model [#263](https://github.com/IN-CORE/pyincore/issues/263)
+- Updated building economic loss analysis to handle case when no occupancy multiplier is provided [#274](https://github.com/IN-CORE/pyincore/issues/274)
 
 ## [1.8.0] - 2022-11-16
 

--- a/pyincore/analyses/buildingeconloss/buildingeconloss.py
+++ b/pyincore/analyses/buildingeconloss/buildingeconloss.py
@@ -40,8 +40,12 @@ class BuildingEconLoss(BaseAnalysis):
         bldg_set = self.get_input_dataset("buildings").get_inventory_reader()
 
         # Occupancy type of the exposure
-        occ_multiplier = self.get_input_dataset("occupancy_multiplier").get_csv_reader()
-        occ_mult_df = pd.DataFrame(occ_multiplier)
+        occ_multiplier = self.get_input_dataset("occupancy_multiplier")
+        if occ_multiplier is not None:
+            occ_multiplier = occ_multiplier.get_csv_reader()
+            occ_mult_df = pd.DataFrame(occ_multiplier)
+        else:
+            occ_mult_df = None
 
         try:
             prop_select = []
@@ -112,7 +116,7 @@ class BuildingEconLoss(BaseAnalysis):
             dmg_set_df = pd.merge(dmg_set_df, occ_mult_df, how="left", left_on="occ_type",
                                   right_on="occ_type", sort=True, copy=True)
         else:
-            dmg_set_df = dmg_set_df["Multiplier"] = 1.0
+            dmg_set_df["Multiplier"] = 1.0
 
         return dmg_set_df
 

--- a/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
+++ b/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
@@ -121,7 +121,7 @@ class HousingRecoverySequential(BaseAnalysis):
         initial_prob['value'] = pd.to_numeric(initial_prob['value'])
 
         # Obtain the number of CPUs (cores) to execute the analysis with
-        user_defined_cpu = 1
+        user_defined_cpu = 4
 
         if not self.get_parameter("num_cpu") is None and self.get_parameter("num_cpu") > 0:
             user_defined_cpu = self.get_parameter("num_cpu")

--- a/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
+++ b/pyincore/analyses/housingrecoverysequential/housingrecoverysequential.py
@@ -413,12 +413,6 @@ class HousingRecoverySequential(BaseAnalysis):
                     'type': 'incore:houseRecInitialStageProbability'
                 },
                 {
-                    'id': 'initial_stage_probabilities',
-                    'required': True,
-                    'description': 'initial mass probability function for stage 0 of the Markov Chain',
-                    'type': 'incore:houseRecInitialStageProbability'
-                },
-                {
                     'id': 'sv_result',
                     'required': True,
                     'description': 'A csv file with zones containing demographic factors'

--- a/pyincore/analyses/joplincge/joplincge.py
+++ b/pyincore/analyses/joplincge/joplincge.py
@@ -59,7 +59,7 @@ class JoplinCGEModel(BaseAnalysis):
                     'description': 'Social accounting matrix (SAM) contains data for firms, '
                                    'households and government which are organized in a way to '
                                    'represent the interactions of all three entities in a typical economy.',
-                    'type': ['incore:JoplinCGEsam']
+                    'type': ['incore:CGEsam']
                 },
                 {
                     'id': 'BB',
@@ -67,14 +67,14 @@ class JoplinCGEModel(BaseAnalysis):
                     'description': 'BB is a matrix which describes how investment in physical infrastructure is'
                                    ' transformed into functioning capital such as commercial and residential buildings.'
                                    ' These data are collected from the Bureau of Economic Analysis (BEA).',
-                    'type': ['incore:JoplinCGEbb']
+                    'type': ['incore:CGEbb']
                 },
                 {
                     'id': 'IOUT',
                     'required': True,
                     'description': 'IOUT is a matrix that describes the transfer of tax revenue collected by the local'
                                    ' government to help finance local government expenditures.',
-                    'type': ['incore:JoplinCGEiout']
+                    'type': ['incore:CGEiout']
                 },
                 {
                     'id': 'MISC',
@@ -82,27 +82,27 @@ class JoplinCGEModel(BaseAnalysis):
                     'description': 'MISC is the name of a file that contains data for commercial sector employment'
                                    ' and physical capital. It also contains data for the number of households and'
                                    ' working households in the economy.',
-                    'type': ['incore:JoplinCGEmisc']
+                    'type': ['incore:CGEmisc']
                 },
                 {
                     'id': 'MISCH',
                     'required': True,
                     'description': 'MISCH is a file that contains elasticities for the supply of labor with'
                                    ' respect to paying income taxes.',
-                    'type': ['incore:JoplinCGEmisch']
+                    'type': ['incore:CGEmisch']
                 },
                 {
                     'id': 'LANDCAP',
                     'required': True,
                     'description': 'LANDCAP contains information regarding elasticity values for the response of '
                                    'changes in the price of physical capital with respect to the supply of investment.',
-                    'type': ['incore:JoplinCGElandcap']
+                    'type': ['incore:CGElandcap']
                 },
                 {
                     'id': 'EMPLOY',
                     'required': True,
                     'description': 'EMPLOY is a table name containing data for commercial sector employment.',
-                    'type': ['incore:JoplinCGEemploy']
+                    'type': ['incore:CGEemploy']
                 },
                 {
                     'id': 'IGTD',
@@ -110,27 +110,27 @@ class JoplinCGEModel(BaseAnalysis):
                     'description': 'IGTD variable represents a matrix describing the transfer of taxes collected'
                                    ' to a variable which permits governments to spend the tax revenue on workers and'
                                    ' intermediate inputs.',
-                    'type': ['incore:JoplinCGEigtd']
+                    'type': ['incore:CGEigtd']
                 },
                 {
                     'id': 'TAUFF',
                     'required': True,
                     'description': 'TAUFF represents social security tax rates',
-                    'type': ['incore:JoplinCGEtauff']
+                    'type': ['incore:CGEtauff']
                 },
                 {
                     'id': 'JOBCR',
                     'required': True,
                     'description': 'JOBCR is a matrix describing the supply of workers'
                                    ' coming from each household group in the economy.',
-                    'type': ['incore:JoplinCGEjobcr']
+                    'type': ['incore:CGEjobcr']
                 },
                 {
                     'id': 'OUTCR',
                     'required': True,
                     'description': 'OUTCR is a matrix describing the number of workers who'
                                    ' live in Joplin but commute outside of town to work.',
-                    'type': ['incore:JoplinCGEoutcr']
+                    'type': ['incore:CGEoutcr']
                 },
                 {
                     'id': 'sector_shocks',

--- a/pyincore/analyses/saltlakecge/saltlakecge.py
+++ b/pyincore/analyses/saltlakecge/saltlakecge.py
@@ -2234,7 +2234,7 @@ class SaltLakeCGEModel(BaseAnalysis):
                     'description': 'Social accounting matrix (SAM) contains data for firms, '
                                    'households and government which are organized in a way to '
                                    'represent the interactions of all three entities in a typical economy.',
-                    'type': ['incore:JoplinCGEsam']
+                    'type': ['incore:CGEsam']
                 },
                 {
                     'id': 'BB',
@@ -2242,14 +2242,14 @@ class SaltLakeCGEModel(BaseAnalysis):
                     'description': 'BB is a matrix which describes how investment in physical infrastructure is'
                                    ' transformed into functioning capital such as commercial and residential buildings.'
                                    ' These data are collected from the Bureau of Economic Analysis (BEA).',
-                    'type': ['incore:JoplinCGEbb']
+                    'type': ['incore:CGEbb']
                 },
                 {
                     'id': 'IOUT',
                     'required': False,
                     'description': 'IOUT is a matrix that describes the transfer of tax revenue collected by the local'
                                    ' government to help finance local government expenditures.',
-                    'type': ['incore:JoplinCGEiout']
+                    'type': ['incore:CGEiout']
                 },
                 {
                     'id': 'MISC',
@@ -2257,34 +2257,34 @@ class SaltLakeCGEModel(BaseAnalysis):
                     'description': 'MISC is the name of a file that contains data for commercial sector employment'
                                    ' and physical capital. It also contains data for the number of households and'
                                    ' working households in the economy.',
-                    'type': ['incore:JoplinCGEmisc']
+                    'type': ['incore:CGEmisc']
                 },
                 {
                     'id': 'MISCH',
                     'required': True,
                     'description': 'MISCH is a file that contains elasticities for the supply of labor with'
                                    ' respect to paying income taxes.',
-                    'type': ['incore:JoplinCGEmisch']
+                    'type': ['incore:CGEmisch']
                 },
                 {
                     'id': 'EMPLOY',
                     'required': True,
                     'description': 'EMPLOY is a table name containing data for commercial sector employment.',
-                    'type': ['incore:JoplinCGEemploy']
+                    'type': ['incore:CGEemploy']
                 },
                 {
                     'id': 'JOBCR',
                     'required': True,
                     'description': 'JOBCR is a matrix describing the supply of workers'
                                    ' coming from each household group in the economy.',
-                    'type': ['incore:JoplinCGEjobcr']
+                    'type': ['incore:CGEjobcr']
                 },
                 {
                     'id': 'OUTCR',
                     'required': True,
                     'description': 'OUTCR is a matrix describing the number of workers who'
                                    ' live in Salt Lake City but commute outside of town to work.',
-                    'type': ['incore:JoplinCGEoutcr']
+                    'type': ['incore:CGEoutcr']
                 },
                 {
                     'id': 'sector_shocks',

--- a/tests/pyincore/analyses/housingrecoveryserial/test_housingrecoverysequential.py
+++ b/tests/pyincore/analyses/housingrecoveryserial/test_housingrecoverysequential.py
@@ -4,11 +4,14 @@
 
 from pyincore import IncoreClient, HHRSOutputProcess
 from pyincore.analyses.housingrecoverysequential import HousingRecoverySequential
+from timeit import default_timer as timer
 import pyincore.globals as pyglobals
 
 
 def run_with_base_class():
     client = IncoreClient(pyglobals.INCORE_API_DEV_URL)
+
+    start = timer()
 
     population_dislocation = "60f098f502897f12fcda19ec"  # dev Galveston testbed
     transition_probability_matrix = "60ef513802897f12fcd9765c"
@@ -23,9 +26,11 @@ def run_with_base_class():
     housing_recovery = HousingRecoverySequential(client)
 
     # Parameter setup
+    housing_recovery.set_parameter('num_cpu', 4)
     housing_recovery.set_parameter('seed', seed)
     housing_recovery.set_parameter('t_delta', t_delta)
     housing_recovery.set_parameter('t_final', t_final)
+    housing_recovery.set_parameter('result_name', 'results_hhrs_galveston.csv')
 
     # Dataset inputs
     housing_recovery.load_remote_input_dataset("population_dislocation_block", population_dislocation)
@@ -38,7 +43,13 @@ def run_with_base_class():
     # test the utilility
     hhr_result = housing_recovery.get_output_dataset("ds_result")
     hhrs_df = hhr_result.get_dataframe_from_csv()
+
+    end = timer()
+
+    print(f'Elapsed time: {end - start:.3f} seconds')
+
     timesteps = ["1", "7", "13", "25", "49"]  # t0, t6, t12, t24, t48
+
     print(HHRSOutputProcess.get_hhrs_stage_count(timesteps, hhrs_df))
 
 

--- a/tests/pyincore/analyses/saltlakecge/test_saltlakecge.py
+++ b/tests/pyincore/analyses/saltlakecge/test_saltlakecge.py
@@ -11,12 +11,12 @@ def run_base_analysis():
     saltlake_cge = SaltLakeCGEModel(client)
 
     saltlake_cge.set_parameter("model_iterations", 1)
-    saltlake_cge.load_remote_input_dataset("SAM", "63a353d94b8432383268cd33")
+    saltlake_cge.load_remote_input_dataset("SAM", "63c8398f4b843238326be519")
     saltlake_cge.load_remote_input_dataset("BB", "63a354f54b8432383268cd92")
-    saltlake_cge.load_remote_input_dataset("MISCH", "63a355a44b8432383268cd9e")
-    saltlake_cge.load_remote_input_dataset("EMPLOY", "63a3563b4b8432383268cece")
-    saltlake_cge.load_remote_input_dataset("JOBCR", "63a356cf4b8432383268ced4")
-    saltlake_cge.load_remote_input_dataset("OUTCR", "63a357ec4b8432383268ceda")
+    saltlake_cge.load_remote_input_dataset("MISCH", "63c838954b843238326be513")
+    saltlake_cge.load_remote_input_dataset("EMPLOY", "63c836d94b843238326bd982")
+    saltlake_cge.load_remote_input_dataset("JOBCR", "63c837f74b843238326be507")
+    saltlake_cge.load_remote_input_dataset("OUTCR", "63c838414b843238326be50d")
     saltlake_cge.load_remote_input_dataset("sector_shocks", "63a358404b8432383268cee0")
 
     saltlake_cge.run_analysis()


### PR DESCRIPTION
[documentation](https://incore.ncsa.illinois.edu/doc/incore/analyses/building_loss.html) says occupancy_multiplier is not required. The code broke when I tried running without an occupancy multiplier file. `.get_csv_read()` on line 43 couldn't handle there being nothing. Updated to check if `occ_multiplier` is `None`. 

Additional issue on line 115 with how `"Multiplier"` was set to `1.0` in `dmg_set_df`