### PR TITLE
367 investigate why multiple datasets being created after running pytest

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          miniforge-version: "latest"
           python-version: 3.8
           use-mamba: true
           mamba-version: "*"

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "py38_23.5.0-3"
+          miniconda-version: "4.7.12.1"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -36,7 +36,7 @@ jobs:
             hashFiles('environment.yml') }}
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-version: "latest"
           mamba-version: "*"

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -36,7 +36,7 @@ jobs:
             hashFiles('environment.yml') }}
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniconda-version: "latest"
           mamba-version: "*"

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -41,7 +41,7 @@ jobs:
           miniconda-version: "4.7.12"
           mamba-version: "*"
           use-mamba: true
-          python-version: 3.10
+          python-version: "3.10"
           activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "latest"
-          mamba-version: "1.4.7"
+          miniconda-version: "23.5.0"
+          mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}
           activate-environment: base

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -41,7 +41,7 @@ jobs:
           miniconda-version: "4.7.12"
           mamba-version: "*"
           use-mamba: true
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.10
           activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniforge-version: latest
+          miniforge-version: "latest"
           mamba-version: "*"
           use-mamba: true
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
           activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   unit_test:
-    platform: linux/x86_64
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -42,8 +42,8 @@ jobs:
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}
-          auto-activate-base: true
-          activate-environment: ""
+          auto-update-conda: true
+          activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true
 

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "23.5.0"
+          miniconda-version: "Miniconda3-py39_23.5.0-3-MacOSX-x86_64.sh"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -39,10 +39,9 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniconda-version: "latest"
-          mamba-version: "*"
-          use-mamba: true
+#          mamba-version: "*"
+#          use-mamba: true
           python-version: ${{ matrix.python-version }}
-          auto-update-conda: true
           activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -42,7 +42,8 @@ jobs:
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: base
+          auto-activate-base: true
+          activate-environment: ""
           environment-file: environment.yml
           use-only-tar-bz2: true
 

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "4.7.12.1"
+          miniconda-version: "4.7.12"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   unit_test:
+    platform: linux/x86_64
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "4.7.12"
+          miniforge-version: latest
           mamba-version: "*"
           use-mamba: true
-          python-version: "3.10"
+          python-version: 3.8
           activate-environment: base
           environment-file: environment.yml
           use-only-tar-bz2: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -36,7 +36,7 @@ jobs:
             hashFiles('environment.yml') }}
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v2 
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: "latest"
           mamba-version: "*"

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "Miniconda3-py39_23.5.0-3-MacOSX-x86_64.sh"
+          miniconda-version: "Miniconda3-py39_23.5.0-3-Linux-x86_64.sh"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "23.5.0-3"
+          miniconda-version: "py38_23.5.0-3"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          miniconda-version: "Miniconda3-py39_23.5.0-3-Linux-x86_64.sh"
+          miniconda-version: "23.5.0-3"
           mamba-version: "*"
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -39,8 +39,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniconda-version: "latest"
-#          mamba-version: "*"
-#          use-mamba: true
+          mamba-version: "1.4.7"
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
           activate-environment: base
           environment-file: environment.yml

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -36,7 +36,7 @@ jobs:
             hashFiles('environment.yml') }}
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2 
         with:
           miniforge-version: "latest"
           mamba-version: "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Expose all the incore client parameters [#295](https://github.com/IN-CORE/pyincore/issues/295)
+- Fixed testing datasets not being cleaned in the database [#367](https://github.com/IN-CORE/pyincore/issues/367)
 
 ### Changed
 - Building Damage supports multiple hazard fragilities [#337](https://github.com/IN-CORE/pyincore/issues/337)

--- a/tests/pyincore/test_hazardservice.py
+++ b/tests/pyincore/test_hazardservice.py
@@ -187,6 +187,9 @@ def test_create_and_delete_earthquake(hazardsvc):
     model_response = hazardsvc.create_earthquake(eqmodel_json)
     assert model_response["id"] is not None
 
+    del_response = hazardsvc.delete_earthquake(model_response["id"])
+    assert del_response["id"] is not None
+
 
 def test_get_earthquake_aleatory_uncertainty(hazardsvc):
     hazard_id = "5c535f57c5c0e4ccead71a1a"


### PR DESCRIPTION
For testing, you can run `test_hazardservice.py` or only its function `def test_create_and_delete_earthquake(hazardsvc)`

This PR also includes workaround for pytest. It passes the workflow and doesn't require testing.