### PR TITLE
393 nonstructural building damage hazard exposure column name is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Aggregate hazard exposure column for non-structural building damage analysis to avoid column name cutoff and 
+  chaining issue with mean damage [#393](https://github.com/IN-CORE/pyincore/issues/393)
+
+
 ## [1.12.0] - 2023-08-16
 
 ### Added

--- a/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
+++ b/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
@@ -287,6 +287,7 @@ class NonStructBuildingDamage(BaseAnalysis):
             hazard_exposure_as = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_as, hazard_type)
             hazard_exposure_ds = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_ds, hazard_type)
             haz_expose = NonStructBuildingUtil.determine_haz_exposure(hazard_exposure_as, hazard_exposure_ds)
+            building_result['haz_expose'] = haz_expose
 
             # put damage results in dictionary
             damage_result = dict()
@@ -300,7 +301,6 @@ class NonStructBuildingDamage(BaseAnalysis):
             damage_result['hazardtype'] = hazard_type
             damage_result['hazardvals_as'] = hazard_vals_as
             damage_result['hazardvals_ds'] = hazard_vals_ds
-            damage_result['haz_expose'] = haz_expose
 
             building_results.append(building_result)
             damage_results.append(damage_result)

--- a/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
+++ b/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingdamage.py
@@ -284,10 +284,9 @@ class NonStructBuildingDamage(BaseAnalysis):
             building_result['DS_DS_1'] = dmg_interval_ds['DS_1']
             building_result['DS_DS_2'] = dmg_interval_ds['DS_2']
             building_result['DS_DS_3'] = dmg_interval_ds['DS_3']
-            building_result['hazard_exposure_as'] = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_as,
-                                                                                                 hazard_type)
-            building_result['hazard_exposure_ds'] = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_ds,
-                                                                                                 hazard_type)
+            hazard_exposure_as = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_as, hazard_type)
+            hazard_exposure_ds = AnalysisUtil.get_exposure_from_hazard_values(hazard_vals_ds, hazard_type)
+            haz_expose = NonStructBuildingUtil.determine_haz_exposure(hazard_exposure_as, hazard_exposure_ds)
 
             # put damage results in dictionary
             damage_result = dict()
@@ -301,6 +300,7 @@ class NonStructBuildingDamage(BaseAnalysis):
             damage_result['hazardtype'] = hazard_type
             damage_result['hazardvals_as'] = hazard_vals_as
             damage_result['hazardvals_ds'] = hazard_vals_ds
+            damage_result['haz_expose'] = haz_expose
 
             building_results.append(building_result)
             damage_results.append(damage_result)

--- a/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingutil.py
+++ b/pyincore/analyses/nonstructbuildingdamage/nonstructbuildingutil.py
@@ -60,3 +60,25 @@ class NonStructBuildingUtil:
             + prob_ground_failure - limit_state_probabilities[keys[j]] * prob_ground_failure
 
         return adjusted_limit_state_probabilities
+
+    @staticmethod
+    def determine_haz_exposure(hazard_exposure_as, hazard_exposure_ds):
+        """
+        Determine the hazard exposure of the building based on the
+        Args:
+            hazard_exposure_as:
+            hazard_exposure_ds:
+
+        Returns:
+
+        """
+        if hazard_exposure_as == "yes" and hazard_exposure_ds == "yes":
+            haz_expose = "yes"
+        elif hazard_exposure_as == "error" or hazard_exposure_ds == "error":
+            haz_expose = "error"
+        elif hazard_exposure_as == "no" and hazard_exposure_ds == "no":
+            haz_expose = "no"
+        else:
+            haz_expose = "partial"
+
+        return haz_expose


### PR DESCRIPTION
@navarroc i took your suggestion to aggregate the ds/as hazard exposure into just one haz_expose to minimize the changing needed. 

Test it by running the pytest as well as the **mean_dmg.ipynb** from `incore_docs`