### PR TITLE
upgraded python from 3.8 to 3.10 for conda build

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           create-args: >-
-            python=3.8
+            python=3.10
             conda
           environment-file: environment.yml
           generate-run-shell: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - CGE warning that using series is deprecated and will raise a type error [#357](https://github.com/IN-CORE/pyincore/issues/357)
+- Upgrade the env of conda build from python 3.8 to 3.10 [#432](https://github.com/IN-CORE/pyincore/issues/432)
 
 
 ## [1.13.0] - 2023-10-11


### PR DESCRIPTION
As long as the action of `Publish Conda package` works. This PR should be good to go.