### PR TITLE
Local repair curve and commercial recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - CGE warning that using series is deprecated and will raise a type error [#357](https://github.com/IN-CORE/pyincore/issues/357)
 - Pytest fix in workflow [#425](https://github.com/IN-CORE/pyincore/issues/425)
-- Mapping rule to match local repair curve
-- Local tornado x and y axis reversed
+- Mapping rule to match local repair curve [#438](https://github.com/IN-CORE/pyincore/issues/438)
+- Local tornado x and y axis reversed [#439](https://github.com/IN-CORE/pyincore/issues/439)
+
 
 ## [1.13.0] - 2023-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - CGE warning that using series is deprecated and will raise a type error [#357](https://github.com/IN-CORE/pyincore/issues/357)
 - Pytest fix in workflow [#425](https://github.com/IN-CORE/pyincore/issues/425)
-
+- Mapping rule to match local repair curve
+- Local tornado x and y axis reversed
 
 ## [1.13.0] - 2023-10-11
 

--- a/pyincore/dfr3service.py
+++ b/pyincore/dfr3service.py
@@ -241,7 +241,8 @@ class Dfr3Service:
 
         # replace the curve id in dfr3_sets to the dfr3 curve
         for inventory_id, curve_item in dfr3_sets.items():
-            if isinstance(curve_item, FragilityCurveSet):
+            if isinstance(curve_item, FragilityCurveSet) or isinstance(curve_item, RepairCurveSet) \
+                    or isinstance(curve_item, RestorationCurveSet):
                 pass
             elif isinstance(curve_item, str):
                 dfr3_sets[inventory_id] = batch_dfr3_sets[curve_item]


### PR DESCRIPTION
To test, 

use below in the `tests/pyincore/analyses/commercialbuildingrecovery/test_commercialbuildingrecovery.py` file

```
# repair curve set
repair_archetype_6 = RepairCurveSet.from_json_file("/Users/cwang138/Documents/Projects/INCORE-2.0/incore-workshop/inspire-workshop-2023-11-15/session4/data/dfr3/repair_archetype_6.json")
repair_archetype_7 = RepairCurveSet.from_json_file("/Users/cwang138/Documents/Projects/INCORE-2.0/incore-workshop/inspire-workshop-2023-11-15/session4/data/dfr3/repair_archetype_7.json")

# define mapping rules
repair_entry_archetype_6 = {"Repair ID Code": repair_archetype_6}
repair_rules_archetype_6 = {"OR": ["int archetype EQUALS 6"]}
repair_mapping_archetype_6 = Mapping(repair_entry_archetype_6, repair_rules_archetype_6)

repair_entry_archetype_7 = {"Repair ID Code": repair_archetype_7}
repair_rules_archetype_7 = {"OR": ["int archetype EQUALS 7"]}
repair_mapping_archetype_7 = Mapping(repair_entry_archetype_7, repair_rules_archetype_7)

# construct mapping
repair_mapping_set_definition = {
    "id": "N/A",
    "name": "Building Mean structural repair cost mapping for archetypes 6 & 7",
    "hazardType": "tornado",
    "inventoryType": "building",
    'mappings': [
        repair_mapping_archetype_6,
        repair_mapping_archetype_7,
    ],
    "mappingType": "repair"
}
repair_mapping_set = MappingSet(repair_mapping_set_definition)
com_recovery.set_input_dataset('dfr3_mapping_set', repair_mapping_set)
```

Here is the attached local repair curves
[Archive.zip](https://github.com/IN-CORE/pyincore/files/13244427/Archive.zip)
