### PR TITLE
447 upgrade python version from 36 to 39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
 
-## [1.14.0] - 2023-11-02
+### Changed
+- Upgrade python version from 3.6 to 3.9 [#447](https://github.com/IN-CORE/pyincore/issues/447)
+
+
+## [1.14.0] - 2023-11-08
 
 ### Changed
 - Properly set the output dataset in Building Portfolio Recovery Analysis [#423](https://github.com/IN-CORE/pyincore/issues/423)

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -33,12 +33,12 @@ requirements:
     - numpy>=1.26.0,<2.0a0
  
   host:
-    - python>=3.6
+    - python>=3.9
     - pip
     - numpy>=1.26.0,<2.0a0
 
   run:
-    - python>=3.6
+    - python>=3.9
     - ipopt>=3.11
     - scip>=8.0.0
     - {{ pin_compatible('numpy') }}

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         '': ['*.ini']
     },
 
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 
     install_requires=[
         'fiona>=1.9.5',


### PR DESCRIPTION
This PR
- upgraded python to >= 3.9
- updated the release date in November 2023