### PR TITLE
401 mcs remove redundant damage columns in the failure probability output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Upgrade python version from 3.6 to 3.9 [#447](https://github.com/IN-CORE/pyincore/issues/447)
+- Update MCS analysis to output only required columns for `failure_probability` [#401](https://github.com/IN-CORE/pyincore/issues/401)
 
 
 ## [1.14.0] - 2023-11-08

--- a/pyincore/analyses/montecarlofailureprobability/montecarlofailureprobability.py
+++ b/pyincore/analyses/montecarlofailureprobability/montecarlofailureprobability.py
@@ -265,7 +265,7 @@ class MonteCarloFailureProbability(BaseAnalysis):
 
         # failure probability
         fp_result = collections.OrderedDict()
-        fp_result.update(dmg)
+        fp_result['guid'] = dmg['guid']
 
         ds_sample = self.sample_damage_interval(dmg, damage_interval_keys,
                                                 num_samples, seed)


### PR DESCRIPTION
This PR updates the MCS analysis to output only the required columns in `failure_probability`. To test, try running pytest or install the current branch with `pip install . -U --no-dependencies` and run the `mc_failure_prob.ipynb` notebook in `incore-docs/notebooks/`