### PR TITLE
Fixed JWT token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Need to use left join so the building number stays the same [#514](https://github.com/IN-CORE/pyincore/issues/541)
 
+### Fixed
+- Fixed JWT token validation [#529](https://github.com/IN-CORE/pyincore/issues/529)
 
 ## [1.17.0] - 2024-02-22
 


### PR DESCRIPTION
In this PR, JWT token validation uses decoding the token itself since the token contains expiration info (the `exp` param). 

This way we don't need to talk to keycloak and have accurate expiration time.