### PR TITLE
Fixed #519 removed unnecessary dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Unnecessary dependency in setup.py [#519](https://github.com/IN-CORE/pyincore/issues/519)
+
 
 ## [1.18.0] - 2024-04-03
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,3 @@ dependencies:
   - rtree>=1.1.0
   - scipy>=1.11.3
   - shapely>=2.0.2
-  - openssl<=3.2.0

--- a/requirements.min
+++ b/requirements.min
@@ -16,4 +16,3 @@ requests>=2.31.0
 rtree>=1.1.0
 scipy>=1.11.3
 shapely>=2.0.2
-openssl<=3.2.0

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         'rtree>=1.1.0',
         'scipy>=1.11.3',
         'shapely>=2.0.2',
-        'openssl<=3.2.0'
     ],
 
     extras_require={


### PR DESCRIPTION
openssl is not available through pip and breaks pip install of pyincore after 1.15.1. The openssl dependency is for conda installation.