### PR TITLE
change dict to list to respect order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed Sphinx autodoc skipping class methods with custom decorators. [#518](https://github.com/IN-CORE/pyincore/issues/518)
 - Pyomo version fixed to fix indp solver failure [#585](https://github.com/IN-CORE/pyincore/issues/585)
+- Uploaded raster files doesn't respect the order [#614](https://github.com/IN-CORE/pyincore/issues/614)
 
 ### Changed
 - Support Interdependent recovery of residential buildings and households [#606](https://github.com/IN-CORE/pyincore/pull/606)

--- a/pyincore/hazardservice.py
+++ b/pyincore/hazardservice.py
@@ -341,10 +341,10 @@ class HazardService:
 
         """
         url = self.base_earthquake_url
-        eq_data = {("earthquake", eq_json)}
+        eq_data = [("earthquake", eq_json)]
 
         for file_path in file_paths:
-            eq_data.add(("file", open(file_path, "rb")))
+            eq_data.append(("file", open(file_path, "rb")))
         kwargs = {"files": eq_data}
         r = self.client.post(url, timeout=timeout, **kwargs)
         return return_http_response(r).json()
@@ -558,10 +558,10 @@ class HazardService:
 
         """
         url = self.base_tornado_url
-        tornado_data = {("tornado", tornado_json)}
+        tornado_data = [("tornado", tornado_json)]
 
         for file_path in file_paths:
-            tornado_data.add(("file", open(file_path, "rb")))
+            tornado_data.append(("file", open(file_path, "rb")))
         kwargs = {"files": tornado_data}
         r = self.client.post(url, timeout=timeout, **kwargs)
         return return_http_response(r).json()
@@ -708,10 +708,10 @@ class HazardService:
         """
 
         url = self.base_tsunami_url
-        tsunami_data = {("tsunami", tsunami_json)}
+        tsunami_data = [("tsunami", tsunami_json)]
 
         for file_path in file_paths:
-            tsunami_data.add(("file", open(file_path, "rb")))
+            tsunami_data.append(("file", open(file_path, "rb")))
         kwargs = {"files": tsunami_data}
         r = self.client.post(url, timeout=timeout, **kwargs)
         return return_http_response(r).json()
@@ -783,10 +783,10 @@ class HazardService:
 
         """
         url = self.base_hurricane_url
-        hurricane_data = {("hurricane", hurricane_json)}
+        hurricane_data = [("hurricane", hurricane_json)]
 
         for file_path in file_paths:
-            hurricane_data.add(("file", open(file_path, "rb")))
+            hurricane_data.append(("file", open(file_path, "rb")))
         kwargs = {"files": hurricane_data}
         r = self.client.post(url, timeout=timeout, **kwargs)
 
@@ -926,10 +926,10 @@ class HazardService:
 
         """
         url = self.base_flood_url
-        flood_data = {("flood", flood_json)}
+        flood_data = [("flood", flood_json)]
 
         for file_path in file_paths:
-            flood_data.add(("file", open(file_path, "rb")))
+            flood_data.append(("file", open(file_path, "rb")))
         kwargs = {"files": flood_data}
         r = self.client.post(url, timeout=timeout, **kwargs)
 

--- a/pyincore/spaceservice.py
+++ b/pyincore/spaceservice.py
@@ -39,7 +39,7 @@ class SpaceService:
 
         """
         url = self.base_space_url
-        space_data = {("space", space_json)}
+        space_data = [("space", space_json)]
         kwargs["files"] = space_data
         r = self.client.post(url, timeout=timeout, **kwargs)
         return return_http_response(r).json()
@@ -215,7 +215,7 @@ class SpaceService:
 
         """
         url = urljoin(self.base_space_url, space_id + "/grant")
-        space_privileges = {("grant", privileges_json)}
+        space_privileges = [("grant", privileges_json)]
         kwargs["files"] = space_privileges
         r = self.client.post(url, timeout=timeout, **kwargs)
 


### PR DESCRIPTION
Anibal reported that when uploading the hurricane rasters with multiple demand types to the Incore services, the returned hazard intensity values differ from the local results. Upon investigation, I found that the order of the files, which should correspond to the demand types, was not being preserved due to the use of a dictionary. I have updated the implementation to use a list instead, which should resolve the issue.

---

To Test:

Run the pytest or monitor the GitHub Action to ensure it passes.