### PR TITLE
Fix GitHub action error in posting the container when merged to main

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - develop
       - 'release/*'
-      - main-temp
 
     tags:
       - '*'
@@ -16,7 +15,6 @@ on:
       - main
       - develop
       - 'release/*'
-      - main-temp
 
 env:
   MAIN_REPO: IN-CORE/pyincore
@@ -44,7 +42,7 @@ jobs:
             BRANCH=${GITHUB_REF##*/}
           fi
           echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
-          if [ "$BRANCH" == "main-temp" ]; then
+          if [ "$BRANCH" == "main" ]; then
             version=$(awk -F= '/^release/ { print $2}' docs/source/conf.py | sed "s/[ ']//g")
             tags="latest"
             oldversion=""

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
       - 'release/*'
+      - main-temp
 
     tags:
       - '*'
@@ -15,6 +16,7 @@ on:
       - main
       - develop
       - 'release/*'
+      - main-temp
 
 env:
   MAIN_REPO: IN-CORE/pyincore
@@ -42,7 +44,7 @@ jobs:
             BRANCH=${GITHUB_REF##*/}
           fi
           echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
-          if [ "$BRANCH" == "main" ]; then
+          if [ "$BRANCH" == "main-temp" ]; then
             version=$(awk -F= '/^release/ { print $2}' docs/source/conf.py | sed "s/[ ']//g")
             tags="latest"
             oldversion=""
@@ -51,6 +53,8 @@ jobs:
               tags="${tags},${version}"
               version=${version%.*}
             done
+            # Remove any unwanted double quotes from tags
+            tags=$(echo $tags | sed 's/"//g')
             echo "VERSION=${version}" >> $GITHUB_ENV
             echo "TAGS=${tags}" >> $GITHUB_ENV
           elif [ "$BRANCH" == "develop" ]; then
@@ -60,6 +64,10 @@ jobs:
             echo "VERSION=testing" >> $GITHUB_ENV
             echo "TAGS=${BRANCH}" >> $GITHUB_ENV
           fi
+
+      # debug TAGS
+      - name: Debug TAGS
+        run: echo "TAGS=${{ env.TAGS }}"
 
       # build image
       - name: Build image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Documentation container tagging error by github action [#631](https://github.com/IN-CORE/pyincore/issues/631)
+
 ## [1.20.1] - 2024-11-01
 
 ### Fixed


### PR DESCRIPTION
There is an error in posting the documentation docker image by github action when the branch gets merged to the main branch. The PR fixes the problem but it is not easy to test unless this PR gets merged to main. I have tested this branch by creating the branch named "main-temp" and made github action to response to the main-temp branch instead of main branch. Then, it worked successfully and posted the docker container with the correct versioning. If you check the [hub.ncsa.illinois.edu](https://hub.ncsa.illinois.edu/harbor/projects/5/repositories/doc%2Fpyincore/artifacts-tab) and see the tag with 1, 1.20, 1.20.1, and latest, that is the result from this PR