### PR TITLE
Fixes #634 Update production URL references to tools.in-core.org and dev to dev.in-core.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation container tagging error by github action [#631](https://github.com/IN-CORE/pyincore/issues/631)
 - Updated rasterio dependency to the latest to fetch correct GDAL version [#636](https://github.com/IN-CORE/pyincore/issues/636)
 
+### Changed
+- Update production URL references to tools.in-core.org and dev to dev.in-core.org [#634](https://github.com/IN-CORE/pyincore/issues/634)
+
 
 ## [1.20.1] - 2024-11-01
 
 ### Fixed
 - CoreCGEML bug and updated base values [#627](https://github.com/IN-CORE/pyincore/issues/627)
-
-### Changed
-- Update production URL references to tools.in-core.org and dev to dev.in-core.org [#634](https://github.com/IN-CORE/pyincore/issues/634)
 
 
 ## [1.20.0] - 2024-10-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - CoreCGEML bug and updated base values [#627](https://github.com/IN-CORE/pyincore/issues/627)
 
+### Changed
+- Update production URL references to tools.in-core.org and dev to dev.in-core.org [#634](https://github.com/IN-CORE/pyincore/issues/634)
+
 
 ## [1.20.0] - 2024-10-24
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ To update **pyIncore**, run
    conda update -c in-core pyincore
 
 You can find detail information at the
-`Installation <https://incore.ncsa.illinois.edu/doc/incore/pyincore/install_pyincore.html>`__
+`Installation <https://tools.in-core.org/doc/incore/pyincore/install_pyincore.html>`__
 section at IN-CORE manual.
 
 Installation with pip
@@ -61,17 +61,17 @@ Testing and Running
 -------------------
 
 Please read the `Testing and
-Running <https://incore.ncsa.illinois.edu/doc/incore/pyincore/running.html>`__
+Running <https://tools.in-core.org/doc/incore/pyincore/running.html>`__
 section at IN-CORE manual.
 
 Documentation
 -------------
 
 **pyIncore** documentation can be found at
-https://incore.ncsa.illinois.edu/doc/incore/pyincore.html
+https://tools.in-core.org/doc/incore/pyincore.html
 
 **pyIncore** technical reference (API) can be found at
-https://incore.ncsa.illinois.edu/doc/pyincore/.
+https://tools.in-core.org/doc/pyincore/.
 
 Acknowledgement
 ---------------

--- a/docs/source/refs.rst
+++ b/docs/source/refs.rst
@@ -5,9 +5,9 @@ References
 
     <embed>
         <ul>
-            <li><a href="https://incore.ncsa.illinois.edu/doc/incore/" target="_blank">IN-CORE</a> Manual</li>
-            <li><a href="https://incore.ncsa.illinois.edu/doc/pyincore_viz/" target="_blank">pyIncore-viz</a> Reference</li>
-            <li><a href="https://incore.ncsa.illinois.edu/doc/pyincore_data/" target="_blank">pyIncore-data</a> Reference</li>
-            <li><a href="https://incore.ncsa.illinois.edu/doc/api/" target="_blank">IN-CORE Web Services API</a> specifications</li>
+            <li><a href="https://tools.in-core.org/doc/incore/" target="_blank">IN-CORE</a> Manual</li>
+            <li><a href="https://tools.in-core.org/doc/pyincore_viz/" target="_blank">pyIncore-viz</a> Reference</li>
+            <li><a href="https://tools.in-core.org/doc/pyincore_data/" target="_blank">pyIncore-data</a> Reference</li>
+            <li><a href="https://tools.in-core.org/doc/api/" target="_blank">IN-CORE Web Services API</a> specifications</li>
         </ul>
     </embed>

--- a/pyincore/globals.py
+++ b/pyincore/globals.py
@@ -12,8 +12,8 @@ import shutil
 
 PACKAGE_VERSION = "1.20.1"
 
-INCORE_API_PROD_URL = "https://incore.ncsa.illinois.edu"
-INCORE_API_DEV_URL = "https://incore-dev.ncsa.illinois.edu"
+INCORE_API_PROD_URL = "https://tools.in-core.org"
+INCORE_API_DEV_URL = "https://dev.in-core.org"
 
 INCORE_INTERNAL_API_URL = "http://localhost:8080"
 

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ..
 
 about:
-  home: https://incore.ncsa.illinois.edu
+  home: https://tools.in-core.org
   license: MPL-2.0
   summary: 'Python library for IN-CORE (Interdependent Networked Community Resilience Modeling Environment)'
   description: 'pyIncore is a component of IN-CORE. It is a python package consisting of two primary components: 
@@ -17,7 +17,7 @@ about:
   package allows users to apply various hazards to infrastructure in selected areas, propagating the effect of 
   physical infrastructure damage and loss of functionality to social and economic impacts.'
   dev_url: https://github.com/IN-CORE/pyincore
-  doc_url: https://incore.ncsa.illinois.edu/doc/incore
+  doc_url: https://tools.in-core.org/doc/incore
 
 build:
   # If this is a new build for the same version, increment the build

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="IN-CORE analysis tool python package",
     long_description=readme,
     long_description_content_type="text/x-rst",
-    url="https://incore.ncsa.illinois.edu",
+    url="https://tools.in-core.org",
     license="Mozilla Public License v2.0",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Dev and production URL references are updated to in-core.org. 