### PR TITLE
Fixes #636 Updated rasterio dependency to fetch correct GDAL version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Updated rasterio dependency to the latest to fetch correct GDAL version [#636](https://github.com/IN-CORE/pyincore/issues/636)
+
+
 ## [1.20.1] - 2024-11-01
 
 ### Fixed

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyproj>=3.6.1
   - pytest>=3.9.0
   - python-jose>=3.0
-  - rasterio>=1.3.9
+  - rasterio>=1.4.2
   - requests>=2.31.0
   - rtree>=1.1.0
   - scipy>=1.11.3

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - pandas>=2.1.2
     - pyomo>=6.0.0,<=6.6.2
     - pyproj>=3.6.1
-    - rasterio>=1.3.9
+    - rasterio>=1.4.2
     - requests>=2.31.0
     - rtree>=1.1.0
     - scipy>=1.11.3

--- a/requirements.min
+++ b/requirements.min
@@ -11,7 +11,7 @@ pyomo>=6.0.0,<=6.6.2
 pyproj>=3.6.1
 pytest>=3.9.0
 python-jose>=3.0
-rasterio>=1.3.9
+rasterio>=1.4.2
 requests>=2.31.0
 rtree>=1.1.0
 scipy>=1.11.3

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "pandas>=2.1.2",
         "pyomo>=6.0.0,<=6.6.2",
         "pyproj>=3.6.1",
-        "rasterio>=1.3.9",
+        "rasterio>=1.4.2",
         "rtree>=1.1.0",
         "scipy>=1.11.3",
         "shapely>=2.0.2",


### PR DESCRIPTION
I updated our rasterio version to the latest (1.4.2) so python 3.9 would fetch 3.9.3 and python 3.10 and above would fetch gdal 3.10.0. 