### PR TITLE
Fixes #654 - changed hazard service earthquake post method to allow soil type dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Hazard service earthquake post method to allow user to specify soil type dataset [#654](https://github.com/IN-CORE/pyincore/issues/654)
+
 ## [1.21.0] - 2025-02-12
 
 ### Changed

--- a/pyincore/analyses/buildingstructuraldamage/buildingstructuraldamage.py
+++ b/pyincore/analyses/buildingstructuraldamage/buildingstructuraldamage.py
@@ -186,6 +186,8 @@ class BuildingStructuralDamage(BaseAnalysis):
         # Get geology dataset id containing liquefaction susceptibility
         geology_dataset_id = self.get_parameter("liquefaction_geology_dataset_id")
 
+        site_class_dataset_id = self.get_parameter("site_class_dataset_id")
+
         multihazard_vals = {}
         adjust_demand_types_mapping = {}
 
@@ -231,6 +233,10 @@ class BuildingStructuralDamage(BaseAnalysis):
                     value_liq = {"demands": [""], "units": [""], "loc": loc}
                     values_payload_liq.append(value_liq)
 
+            if hazard_type == "earthquake" and site_class_dataset_id is not None:
+                # Add site class dataset id if set to get soil type information
+                value = {"siteClassId": site_class_dataset_id}
+                values_payload.append(value)
             hazard_vals = hazard.read_hazard_values(values_payload, self.hazardsvc)
 
             # map demand type from payload to response
@@ -456,6 +462,12 @@ class BuildingStructuralDamage(BaseAnalysis):
                     "id": "liquefaction_geology_dataset_id",
                     "required": False,
                     "description": "Geology dataset id",
+                    "type": str,
+                },
+                {
+                    "id": "site_class_dataset_id",
+                    "required": False,
+                    "description": "Site classification dataset id containing soil type information.",
                     "type": str,
                 },
             ],

--- a/pyincore/hazardservice.py
+++ b/pyincore/hazardservice.py
@@ -208,10 +208,17 @@ class HazardService:
 
         """
         url = urljoin(self.base_earthquake_url, hazard_id + "/values")
+        site_class_dataset_id = ""
+        value = payload[len(payload) - 1]
+        if "siteClassId" in value:
+            payload = payload[:-1]
+            site_class_dataset_id = value["siteClassId"]
+
         kwargs = {
             "files": {
                 ("points", json.dumps(payload)),
                 ("amplifyHazard", json.dumps(amplify_hazard)),
+                ("siteClassId", site_class_dataset_id),
             }
         }
         r = self.client.post(url, timeout=timeout, **kwargs)


### PR DESCRIPTION
I noticed that the Java service endpoint for earthquake allows a user to specify the soil type information, but the python method doesn't have any way to add the dataset id so the service will amplify the hazard based on the soil information at the location specified (otherwise it defaults to whatever soil type is specified when creating the earthquake).

Rather than adding another parameter to the method and then updating the earthquake python model, I added this information to the payload and checked for it in the service to see if it's present. I am not sure if this is the best way to do this so I am open to other options.

