### PR TITLE
Fixes #667 - network analyses check for network dataset input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Descriptions of the analyses, inputs and parameters. [#646](https://github.com/IN-CORE/pyincore/issues/646)
 - Descriptions of the analyses to be more verbose. [#647](https://github.com/IN-CORE/pyincore/issues/647)
 
+### Fixed
+- Network analyses to check if a network dataset is set by the user. [#667](https://github.com/IN-CORE/pyincore/issues/667)
+
 
 ## [1.21.0] - 2025-02-12
 

--- a/pyincore/analyses/epnfunctionality/epnfunctionality.py
+++ b/pyincore/analyses/epnfunctionality/epnfunctionality.py
@@ -26,9 +26,12 @@ class EpnFunctionality(BaseAnalysis):
         """Execute electric power facility functionality analysis"""
 
         # get network dataset
-        network_dataset = NetworkDataset.from_dataset(
-            self.get_input_dataset("epn_network")
-        )
+        network_dataset = self.get_input_dataset("epn_network")
+        if not isinstance(network_dataset, NetworkDataset):
+            network_dataset = NetworkDataset.from_dataset(
+                self.get_input_dataset("epn_network")
+            )
+
         links_epl_gdf = network_dataset.links.get_dataframe_from_shapefile()
         nodes_epf_gdf = network_dataset.nodes.get_dataframe_from_shapefile()
         links_epl_gdf["weight"] = links_epl_gdf.loc[:, "length_km"]
@@ -181,9 +184,9 @@ class EpnFunctionality(BaseAnalysis):
         return {
             "name": "epn-functionality",
             "description": "This analysis computes the functionality of electric power networks. The computation uses "
-                           "sample failure states as well as the network topology of electric power line to determine "
-                           "the functionality probability and failure states for a corresponding electric power "
-                           "facility network by performing a reachability analysis.",
+            "sample failure states as well as the network topology of electric power line to determine "
+            "the functionality probability and failure states for a corresponding electric power "
+            "facility network by performing a reachability analysis.",
             "input_parameters": [
                 {
                     "id": "result_name",

--- a/pyincore/analyses/ncifunctionality/ncifunctionality.py
+++ b/pyincore/analyses/ncifunctionality/ncifunctionality.py
@@ -51,9 +51,12 @@ class NciFunctionality(BaseAnalysis):
         discretized_days = self.get_parameter("discretized_days")
 
         # Load all dataset-related entities for EPF
-        epf_network_dataset = NetworkDataset.from_dataset(
-            self.get_input_dataset("epf_network")
-        )
+        epf_network_dataset = self.get_input_dataset("epn_network")
+        if not isinstance(epf_network_dataset, NetworkDataset):
+            epf_network_dataset = NetworkDataset.from_dataset(
+                self.get_input_dataset("epn_network")
+            )
+
         epf_network_nodes = epf_network_dataset.nodes.get_dataframe_from_shapefile()
         epf_network_links = epf_network_dataset.links.get_dataframe_from_shapefile()
 

--- a/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
+++ b/pyincore/analyses/tornadoepndamage/tornadoepndamage.py
@@ -96,9 +96,12 @@ class TornadoEpnDamage(BaseAnalysis):
         super(TornadoEpnDamage, self).__init__(incore_client)
 
     def run(self):
-        network_dataset = NetworkDataset.from_dataset(
-            self.get_input_dataset("epn_network")
-        )
+        network_dataset = self.get_input_dataset("epn_network")
+        if not isinstance(network_dataset, NetworkDataset):
+            network_dataset = NetworkDataset.from_dataset(
+                self.get_input_dataset("epn_network")
+            )
+
         tornado = self.get_input_hazard("hazard")
         tornado_id = self.get_parameter("tornado_id")
         if tornado is None and tornado_id is None:

--- a/pyincore/analyses/wfnfunctionality/wfnfunctionality.py
+++ b/pyincore/analyses/wfnfunctionality/wfnfunctionality.py
@@ -34,9 +34,12 @@ class WfnFunctionality(BaseAnalysis):
         pumpstation_nodes = self.get_parameter("pumpstation_node_list")
 
         # Get network dataset
-        network_dataset = NetworkDataset.from_dataset(
-            self.get_input_dataset("wfn_network")
-        )
+        network_dataset = self.get_input_dataset("wfn_network")
+        if not isinstance(network_dataset, NetworkDataset):
+            network_dataset = NetworkDataset.from_dataset(
+                self.get_input_dataset("wfn_network")
+            )
+
         edges_wfl_gdf = network_dataset.links.get_dataframe_from_shapefile()
 
         nodes_wfn_gdf = network_dataset.nodes.get_dataframe_from_shapefile()


### PR DESCRIPTION
This fix allows a user to specify a local network dataset as input to the analysis. The analysis checks to see if the input is an instance of a network dataset and if it is, uses it as is. If it's a Dataset type, then it will attempt to load the network dataset from the Dataset. Previously, it always assumed it was a Dataset and tried to load it into a NetworkDataset. 

