### PR TITLE
change capital shocks analysis to output missing guid sectors too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Descriptions of the analyses, inputs and parameters. [#646](https://github.com/IN-CORE/pyincore/issues/646)
 - Descriptions of the analyses to be more verbose. [#647](https://github.com/IN-CORE/pyincore/issues/647)
 - Hazard service earthquake post method to allow user to specify soil type dataset [#654](https://github.com/IN-CORE/pyincore/issues/654)
+- Capital Shocks analysis to also output Sectors in building to sector mappings with no guids as unit shocks. [#671](https://github.com/IN-CORE/pyincore/issues/671)
 
 ### Fixed
 - Building retrofit fails with local building dataset. [#617](https://github.com/IN-CORE/pyincore/issues/617)

--- a/pyincore/analyses/capitalshocks/capitalshocks.py
+++ b/pyincore/analyses/capitalshocks/capitalshocks.py
@@ -109,13 +109,15 @@ class CapitalShocks(BaseAnalysis):
             sector_values = inventory_failure.loc[
                 (inventory_failure["sector"] == sector)
             ]
-            sector_cap = sector_values["cap_rem"].sum()
-            sector_total = sector_values["appr_bldg"].sum()
-            if sector_total == 0:
-                continue
-            sector_shock = np.divide(sector_cap, sector_total)
-            sector_shocks[sector] = sector_shock
-
+            if sector_values.empty:
+                sector_shocks[sector] = 1.0
+            else:
+                sector_cap = sector_values["cap_rem"].sum()
+                sector_total = sector_values["appr_bldg"].sum()
+                if sector_total == 0:
+                    continue
+                sector_shock = np.divide(sector_cap, sector_total)
+                sector_shocks[sector] = sector_shock
         sector_shocks = pd.DataFrame(sector_shocks.items(), columns=["sector", "shock"])
         result_name = self.get_parameter("result_name")
         self.set_result_csv_data(


### PR DESCRIPTION
This PR will tweak the capital shocks analysis to also output sectors that do not have guids in the building to sector mapping file with unit shocks.