### PR TITLE
676 update pytest matrix for python 313 and 314

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           create-args: >-
-            python=3.9
+            python=3.10
             conda
           environment-file: environment.yml
           generate-run-shell: true

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         vars: [ {python-version: '3.9', sleep: '0s'}, {python-version: '3.10', sleep: '60s'},
                 {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'},
-                {python-version: '3.13', sleep: '240s'}, {python-version: '3.14', sleep: '300s'} ]
+                {python-version: '3.13', sleep: '240s'} ]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,8 +15,7 @@ jobs:
     strategy:
       matrix:
         vars: [ {python-version: '3.10', sleep: '0s'}, {python-version: '3.11', sleep: '60s'},
-                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'},
-                {python-version: '3.14', sleep: '240s'}]
+                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'}]
 
     name: Python ${{ matrix.vars.python-version }} Test
     steps:

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         vars: [ {python-version: '3.9', sleep: '0s'}, {python-version: '3.10', sleep: '60s'},
                 {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'},
-                {python-version: '3.13', sleep: '240s'}, {python-version: '3.13', sleep: '300s'} ]
+                {python-version: '3.13', sleep: '240s'}, {python-version: '3.14', sleep: '300s'} ]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        vars: [ {python-version: '3.9', sleep: '0s'}, {python-version: '3.10', sleep: '60s'},
-                {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'},
-                {python-version: '3.13', sleep: '240s'} ]
+        vars: [ {python-version: '3.10', sleep: '0s'}, {python-version: '3.11', sleep: '60s'},
+                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'},
+                {python-version: '3.14', sleep: '240s'} ]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         vars: [ {python-version: '3.9', sleep: '0s'}, {python-version: '3.10', sleep: '60s'},
                 {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'},
-                {python-version: '3.13', sleep: '240s'} ]
+                {python-version: '3.13', sleep: '240s'}, {python-version: '3.13', sleep: '300s'} ]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         vars: [ {python-version: '3.9', sleep: '0s'}, {python-version: '3.10', sleep: '60s'},
-                {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'} ]
+                {python-version: '3.11', sleep: '120s'}, {python-version: '3.12', sleep: '180s'},
+                {python-version: '3.13', sleep: '240s'} ]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         vars: [ {python-version: '3.10', sleep: '0s'}, {python-version: '3.11', sleep: '60s'},
-                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'}
+                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'},
                 {python-version: '3.14', sleep: '240s'}]
 
     name: Python ${{ matrix.vars.python-version }} Test

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       matrix:
         vars: [ {python-version: '3.10', sleep: '0s'}, {python-version: '3.11', sleep: '60s'},
-                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'}]
+                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'}
+                {python-version: '3.14', sleep: '240s'}]
+
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,8 +15,7 @@ jobs:
     strategy:
       matrix:
         vars: [ {python-version: '3.10', sleep: '0s'}, {python-version: '3.11', sleep: '60s'},
-                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'},
-                {python-version: '3.14', sleep: '240s'} ]
+                {python-version: '3.12', sleep: '120s'}, {python-version: '3.13', sleep: '180s'}]
     name: Python ${{ matrix.vars.python-version }} Test
     steps:
       - name: Checkout source code

--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,10 @@ dependencies:
   - geopandas>=0.14.0
   - matplotlib>=3.8.0
   - networkx>=3.2.1
-  - numpy>=1.26.0,<2.0a0
+  - numpy>=1.26.0
   - pandas>=2.1.2
   - pycodestyle>=2.6.0
-  - pyomo>=6.0.0,<=6.6.2
+  - pyomo>=6.0.0
   - pyproj>=3.6.1
   - pytest>=3.9.0
   - python-jose>=3.0

--- a/pyincore/analyses/indp/indp.py
+++ b/pyincore/analyses/indp/indp.py
@@ -31,6 +31,8 @@ class INDP(BaseAnalysis):
     a family of centralized Mixed-Integer Programming (MIP) models. These models determine the optimal restoration
     strategy for disrupted networked systems while considering budget and operational constraints.
 
+    Note: This analysis requires pyomo <= 6.6.2. Higher versions fail to run.
+
     Contributors
         | Science: Hesam Talebiyan
         | Implementation: Chen Wang and NCSA IN-CORE Dev Team

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - numpy>=1.26.0
 
   run:
-    - python>=3.9
+    - python<3.13
     - ipopt>=3.11
     - scip>=8.0.0
     - numpy>=1.26.0

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - python>=3.9
     - ipopt>=3.11
     - scip>=8.0.0
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.26.0
     - fiona>=1.9.5
     - geopandas>=0.14.0
     - matplotlib>=3.8.0

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -28,12 +28,12 @@ build:
  
 requirements:
   build:
-    - python<3.14
+    - python<3.13
     - pip
     - numpy>=1.26.0
  
   host:
-    - python<3.14
+    - python<3.13
     - pip
     - numpy>=1.26.0
 

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -28,12 +28,12 @@ build:
  
 requirements:
   build:
-    - python>=3.9
+    - python<3.14
     - pip
     - numpy>=1.26.0
  
   host:
-    - python>=3.9
+    - python<3.14
     - pip
     - numpy>=1.26.0
 

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -30,12 +30,12 @@ requirements:
   build:
     - python>=3.9
     - pip
-    - numpy>=1.26.0,<2.0a0
+    - numpy>=1.26.0
  
   host:
     - python>=3.9
     - pip
-    - numpy>=1.26.0,<2.0a0
+    - numpy>=1.26.0
 
   run:
     - python>=3.9
@@ -47,7 +47,7 @@ requirements:
     - matplotlib>=3.8.0
     - networkx>=3.2.1
     - pandas>=2.1.2
-    - pyomo>=6.0.0,<=6.6.2
+    - pyomo>=6.0.0
     - pyproj>=3.6.1
     - rasterio>=1.4.2
     - requests>=2.31.0


### PR DESCRIPTION
This only added 3.13 for now since 3.14 was just released and some dependent libraries will need to be updated by package maintainers.